### PR TITLE
Implementation of substance designer integration 

### DIFF
--- a/client/ayon_substancedesigner/__init__.py
+++ b/client/ayon_substancedesigner/__init__.py
@@ -1,0 +1,13 @@
+from .version import __version__
+from .addon import (
+    SubstanceDesignerAddon,
+    SUBSTANCE_DESIGNER_HOST_DIR,
+)
+
+
+__all__ = (
+    "__version__",
+
+    "SubstanceDesignerAddon",
+    "SUBSTANCE_DESIGNER_HOST_DIR"
+)

--- a/client/ayon_substancedesigner/addon.py
+++ b/client/ayon_substancedesigner/addon.py
@@ -1,0 +1,34 @@
+import os
+from ayon_core.addon import AYONAddon, IHostAddon
+
+from .version import __version__
+
+SUBSTANCE_DESIGNER_HOST_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+class SubstanceDesignerAddon(AYONAddon, IHostAddon):
+    name = "substancedesigner"
+    version = __version__
+    host_name = "substancedesigner"
+
+    def add_implementation_envs(self, env, _app):
+        # Add requirements to SUBSTANCE_PAINTER_PLUGINS_PATH
+        plugin_path = os.path.join(SUBSTANCE_DESIGNER_HOST_DIR, "deploy")
+        plugin_path = plugin_path.replace("\\", "/")
+        if env.get("SBS_DESIGNER_PYTHON_PATH"):
+            plugin_path += os.pathsep + env["SBS_DESIGNER_PYTHON_PATH"]
+
+        env["SBS_DESIGNER_PYTHON_PATH"] = plugin_path
+
+        # Log in Substance Painter doesn't support custom terminal colors
+        env["AYON_LOG_NO_COLORS"] = "1"
+
+    def get_launch_hook_paths(self, app):
+        if app.host_name != self.host_name:
+            return []
+        return [
+            os.path.join(SUBSTANCE_DESIGNER_HOST_DIR, "hooks")
+        ]
+
+    def get_workfile_extensions(self):
+        return [".sbs", ".sbsar", ".sbsasm"]

--- a/client/ayon_substancedesigner/api/__init__.py
+++ b/client/ayon_substancedesigner/api/__init__.py
@@ -1,0 +1,8 @@
+from .pipeline import (
+    SubstanceDesignerHost,
+
+)
+
+__all__ = [
+    "SubstanceDesignerHost",
+]

--- a/client/ayon_substancedesigner/api/lib.py
+++ b/client/ayon_substancedesigner/api/lib.py
@@ -2,9 +2,6 @@ import sd
 import json
 import ast
 
-import six
-
-import contextlib
 from sd.api.sdapiobject import APIException
 from sd.api.sdvalueserializer import SDValueSerializer
 
@@ -54,9 +51,12 @@ def set_sd_metadata(metadata_type: str, metadata: dict):
         metadata (dict): AYON-related metadata
     """
     # Need to convert dict to string first
+    target_package = get_package_from_current_graph()
+    existing_container_data = parsing_sd_data_to_dict(target_package, metadata_type)
+    if existing_container_data:
+        metadata.update(existing_container_data)
     metadata_to_str = f"{json.dumps(metadata)}"
     metadata_value = sd.api.sdvaluestring.SDValueString.sNew(metadata_to_str)
-    target_package = get_package_from_current_graph()
     package_metadata_dict = target_package.getMetadataDict()
     package_metadata_dict.setPropertyValueFromId(metadata_type, metadata_value)
 

--- a/client/ayon_substancedesigner/api/lib.py
+++ b/client/ayon_substancedesigner/api/lib.py
@@ -1,6 +1,6 @@
+# -*- coding: utf-8 -*-
 import sd
 import json
-import ast
 import contextlib
 
 from sd.api.sdapiobject import APIException
@@ -52,10 +52,7 @@ def set_sd_metadata(metadata_type: str, metadata):
     """
     # Need to convert dict to string first
     target_package = get_package_from_current_graph()
-    if isinstance(metadata, list):
-        metadata_to_str = f"{metadata}"
-    else:
-        metadata_to_str = f"{json.dumps(metadata)}"
+    metadata_to_str = f"{json.dumps(metadata)}"
     metadata_value = sd.api.sdvaluestring.SDValueString.sNew(metadata_to_str)
     package_metadata_dict = target_package.getMetadataDict()
     package_metadata_dict.setPropertyValueFromId(metadata_type, metadata_value)
@@ -74,9 +71,8 @@ def parsing_sd_data(target_package, metadata_type: str, is_dictionary=True):
     metadata = {} if is_dictionary else []
     package_metadata_dict = target_package.getMetadataDict()
     with contextlib.suppress(APIException):
-        metadata_sd_value = package_metadata_dict.getPropertyValueFromId(
-            metadata_type)
-        metadata_value = SDValueSerializer.sToString(metadata_sd_value)
-        metadata = ast.literal_eval(str(metadata_value))
+        metadata_value = package_metadata_dict.getPropertyValueFromId(
+            metadata_type).get()
+        metadata = json.loads(metadata_value)
 
     return metadata

--- a/client/ayon_substancedesigner/api/lib.py
+++ b/client/ayon_substancedesigner/api/lib.py
@@ -21,7 +21,8 @@ def qt_ui_manager():
     """Get Qt Python UI Manager of Substance Designer
 
     Returns:
-        sd.api.qtforpythonuimgrwrapper.QtForPythonUIMgrWrapper: Qt Python UI Manager
+        sd.api.qtforpythonuimgrwrapper.QtForPythonUIMgrWrapper: Qt Python
+            UI Manager
     """
     ctx = sd.getContext()
     sd_app = ctx.getSDApplication()

--- a/client/ayon_substancedesigner/api/lib.py
+++ b/client/ayon_substancedesigner/api/lib.py
@@ -4,7 +4,6 @@ import json
 import contextlib
 
 from sd.api.sdapiobject import APIException
-from sd.api.sdvalueserializer import SDValueSerializer
 
 
 def package_manager():

--- a/client/ayon_substancedesigner/api/lib.py
+++ b/client/ayon_substancedesigner/api/lib.py
@@ -56,13 +56,36 @@ def get_current_graph_name():
     return current_graph.getIdentifier()
 
 
-def get_map_identifiers_by_graph(target_graph):
+def get_sd_graph_by_name(graph_name):
+    """Get SD graph base on its name
+
+    Args:
+        graph_name (str): SD graph name
+
+    Returns:
+        sd.api.sdgraph.SDGraph: SD Graph
+    """
+    pkg_mgr = package_manager()
+    for package in pkg_mgr.getUserPackages():
+        for resource in package.getChildrenResources(True):
+            if (
+                resource.getClassName() == "SDGraph"
+                and resource.getIdentifier() == graph_name
+            ):
+                return resource
+
+
+def get_map_identifiers_by_graph(target_graph_name):
     """Get map identifiers of the target SD graph
 
     Args:
-        target_graph (sd.api.sdgraph.SDGraph): SD Graph
+        target_graph_name (str): target SD graph name
+
+    Returns:
+        list: all map identifiers
     """
     all_map_identifiers = []
+    target_graph = get_sd_graph_by_name(target_graph_name)
     for output_node in target_graph.getOutputNodes():
         for output in output_node.getProperties(
             sd.api.sdproperty.SDPropertyCategory.Output):

--- a/client/ayon_substancedesigner/api/lib.py
+++ b/client/ayon_substancedesigner/api/lib.py
@@ -69,7 +69,7 @@ def get_sd_graph_by_name(graph_name):
     for package in pkg_mgr.getUserPackages():
         for resource in package.getChildrenResources(True):
             if (
-                resource.getClassName() == "SDGraph"
+                resource.getClassName() == "SDSBSCompGraph"
                 and resource.getIdentifier() == graph_name
             ):
                 return resource

--- a/client/ayon_substancedesigner/api/lib.py
+++ b/client/ayon_substancedesigner/api/lib.py
@@ -1,0 +1,37 @@
+import sd
+
+
+def package_manager():
+    """Get Package Manager of Substance Designer
+
+    Returns:
+        sd.api.sdpackagemgr.SDPackageMgr: Package Manager
+    """
+    app = sd.getContext().getSDApplication()
+    pkg_mgr = app.getPackageMgr()
+    return pkg_mgr
+
+
+def qt_ui_manager():
+    """Get Qt Python UI Manager of Substance Designer
+
+    Returns:
+        sd.api.qtforpythonuimgrwrapper.QtForPythonUIMgrWrapper: Qt Python UI Manager
+    """
+    ctx = sd.getContext()
+    sd_app = ctx.getSDApplication()
+    qt_ui_mgr = sd_app.getQtForPythonUIMgr()
+    return qt_ui_mgr
+
+
+def get_package_from_current_graph():
+    """Get Package from the current graph.
+
+    Returns:
+        sd.api.sdpackage.SDPackage: A package with SDResource
+    """
+    qt_ui = qt_ui_manager()
+    current_graph = qt_ui.getCurrentGraph()
+    if not current_graph:
+        return None
+    return current_graph.getPackage()

--- a/client/ayon_substancedesigner/api/lib.py
+++ b/client/ayon_substancedesigner/api/lib.py
@@ -42,6 +42,35 @@ def get_package_from_current_graph():
     return current_graph.getPackage()
 
 
+def get_current_graph_name():
+    """Get the name of the current SD graph
+
+    Returns:
+        str: current SD graph name
+    """
+    qt_ui = qt_ui_manager()
+    current_graph = qt_ui.getCurrentGraph()
+    if not current_graph:
+        return None
+
+    return current_graph.getIdentifier()
+
+
+def get_map_identifiers_by_graph(target_graph):
+    """Get map identifiers of the target SD graph
+
+    Args:
+        target_graph (sd.api.sdgraph.SDGraph): SD Graph
+    """
+    all_map_identifiers = []
+    for output_node in target_graph.getOutputNodes():
+        for output in output_node.getProperties(
+            sd.api.sdproperty.SDPropertyCategory.Output):
+                all_map_identifiers.append(output.getId())
+
+    return all_map_identifiers
+
+
 def set_sd_metadata(metadata_type: str, metadata):
     """Set AYON-related metadata in Substance Painter
 

--- a/client/ayon_substancedesigner/api/pipeline.py
+++ b/client/ayon_substancedesigner/api/pipeline.py
@@ -124,7 +124,8 @@ class SubstanceDesignerHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         if not current_package:
             return {}
 
-        return parsing_sd_data(current_package, AYON_METADATA_CONTEXT_KEY) or {}
+        return parsing_sd_data(
+            current_package, AYON_METADATA_CONTEXT_KEY) or {}
 
 
     def _install_menu(self):
@@ -134,7 +135,9 @@ class SubstanceDesignerHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
         project_settings = get_current_project_settings()
         tab_menu_label = os.environ.get("AYON_MENU_LABEL") or "AYON"
-        menu = qt_ui.newMenu(menuTitle=tab_menu_label, objectName=tab_menu_label)
+        menu = qt_ui.newMenu(
+            menuTitle=tab_menu_label, objectName=tab_menu_label
+        )
 
         action = menu.addAction("Create...")
         action.triggered.connect(
@@ -191,7 +194,8 @@ class SubstanceDesignerHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         self.menu = None
 
 
-def imprint(current_package, name, namespace, context, loader, identifier, options=None):
+def imprint(current_package, name, namespace, context,
+            loader, identifier, options=None):
     """Imprint a loaded container with metadata.
 
     Containerisation enables a tracking of version, author and origin

--- a/client/ayon_substancedesigner/api/pipeline.py
+++ b/client/ayon_substancedesigner/api/pipeline.py
@@ -68,12 +68,10 @@ class SubstanceDesignerHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         # self._deregister_callbacks()
 
     def workfile_has_unsaved_changes(self):
-        pkg_mgr = package_manager()
-        for package in pkg_mgr.getUserPackages():
-            if package.isModified():
-                return True
-            else:
-                return False
+        package = get_package_from_current_graph()
+        if not package:
+            return False
+        return package.isModified()
 
     def get_workfile_extensions(self):
         return [".sbs", ".sbsar", ".sbsasm"]

--- a/client/ayon_substancedesigner/api/pipeline.py
+++ b/client/ayon_substancedesigner/api/pipeline.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+"""Pipeline tools for Ayon Substance Designer integration."""
+import os
+import logging
+
+# Substance 3D Designer modules
+import sd
+
+import pyblish.api
+
+from ayon_core.host import HostBase, IWorkfileHost, ILoadHost, IPublishHost
+
+from ayon_core.pipeline import (
+    register_creator_plugin_path,
+    register_loader_plugin_path
+)
+
+from ayon_substancedesigner import SUBSTANCE_DESIGNER_HOST_DIR
+
+from .lib import (
+    package_manager,
+    qt_ui_manager,
+    get_package_from_current_graph
+)
+
+
+log = logging.getLogger("ayon_substancedesigner")
+
+PLUGINS_DIR = os.path.join(SUBSTANCE_DESIGNER_HOST_DIR, "plugins")
+PUBLISH_PATH = os.path.join(PLUGINS_DIR, "publish")
+LOAD_PATH = os.path.join(PLUGINS_DIR, "load")
+CREATE_PATH = os.path.join(PLUGINS_DIR, "create")
+INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
+
+AYON_METADATA_KEY = "AYON"
+AYON_METADATA_CONTAINERS_KEY = "containers"  # child key
+AYON_METADATA_CONTEXT_KEY = "context"        # child key
+AYON_METADATA_INSTANCES_KEY = "instances"    # child key
+
+
+class SubstanceDesignerHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
+    name = "substancedesigner"
+
+    def __init__(self):
+        super(SubstanceDesignerHost, self).__init__()
+        self._has_been_setup = False
+        self.menu = None
+        self.callbacks = []
+        self.shelves = []
+
+    def install(self):
+        pyblish.api.register_host("substancedesigner")
+
+        pyblish.api.register_plugin_path(PUBLISH_PATH)
+        register_loader_plugin_path(LOAD_PATH)
+        register_creator_plugin_path(CREATE_PATH)
+
+        # log.info("Installing callbacks ... ")
+        # self._register_callbacks()
+
+        log.info("Installing menu ... ")
+        self._install_menu()
+
+        self._has_been_setup = True
+
+    def uninstall(self):
+        self._uninstall_menu()
+        # self._deregister_callbacks()
+
+    def workfile_has_unsaved_changes(self):
+        pkg_mgr = package_manager()
+        for package in pkg_mgr.getUserPackages():
+            if package.isModified():
+                return True
+            else:
+                return False
+
+    def get_workfile_extensions(self):
+        return [".sbs", ".sbsar", ".sbsasm"]
+
+    def save_workfile(self, dst_path=None):
+        pkg_mgr = package_manager()
+        package = get_package_from_current_graph()
+        if package:
+            pkg_mgr.savePackageAs(package, fileAbsPath=dst_path)
+            return dst_path
+
+    def open_workfile(self, filepath):
+        pkg_mgr = package_manager()
+        pkg_mgr.loadUserPackage(
+            filepath, updatePackages=False, reloadIfModified=False
+        )
+        return filepath
+
+    def get_current_workfile(self):
+        package = get_package_from_current_graph()
+        if package:
+            return package.getFilePath()
+
+        return None
+
+    def _install_menu(self):
+        from ayon_core.tools.utils import host_tools
+        qt_ui = qt_ui_manager()
+        parent = qt_ui.getMainWindow()
+
+        tab_menu_label = os.environ.get("AYON_MENU_LABEL") or "AYON"
+        menu = qt_ui.newMenu(menuTitle=tab_menu_label, objectName=tab_menu_label)
+
+        action = menu.addAction("Create...")
+        action.triggered.connect(
+            lambda: host_tools.show_publisher(parent=parent,
+                                              tab="create")
+        )
+
+        action = menu.addAction("Load...")
+        action.triggered.connect(
+            lambda: host_tools.show_loader(parent=parent, use_context=True)
+        )
+
+        action = menu.addAction("Publish...")
+        action.triggered.connect(
+            lambda: host_tools.show_publisher(parent=parent,
+                                              tab="publish")
+        )
+
+        action = menu.addAction("Manage...")
+        action.triggered.connect(
+            lambda: host_tools.show_scene_inventory(parent=parent)
+        )
+
+        action = menu.addAction("Library...")
+        action.triggered.connect(
+            lambda: host_tools.show_library_loader(parent=parent)
+        )
+
+        menu.addSeparator()
+        action = menu.addAction("Work Files...")
+        action.triggered.connect(
+            lambda: host_tools.show_workfiles(parent=parent)
+        )
+        self.menu = menu
+
+    def _uninstall_menu(self):
+        if self.menu:
+            # self.menu.destroy()
+            tab_menu_label = os.environ.get("AYON_MENU_LABEL") or "AYON"
+            ctx = sd.getContext()
+            sd_app = ctx.getSDApplication()
+            ui_mgr = sd_app.getQtForPythonUIMgr()
+            # Delete the menu
+            if ui_mgr.findMenuFromObjectName() == tab_menu_label:
+                ui_mgr.deleteMenu(objectName=tab_menu_label)
+
+        self.menu = None

--- a/client/ayon_substancedesigner/api/pipeline.py
+++ b/client/ayon_substancedesigner/api/pipeline.py
@@ -115,7 +115,7 @@ class SubstanceDesignerHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         if not current_package:
             return
 
-        set_sd_metadata(current_package, AYON_METADATA_CONTEXT_KEY)
+        set_sd_metadata(AYON_METADATA_CONTEXT_KEY, data)
 
     def get_context_data(self):
         current_package = get_package_from_current_graph()

--- a/client/ayon_substancedesigner/api/pipeline.py
+++ b/client/ayon_substancedesigner/api/pipeline.py
@@ -228,3 +228,45 @@ def remove_container_metadata(container):
         if container_data["objectName"] != container["objectName"]
     ]
     set_sd_metadata(AYON_METADATA_CONTAINERS_KEY, metadata_remainder)
+
+
+def set_instance(instance_id, instance_data, update=False):
+    """Helper method to directly set the data for a specific container
+
+    Args:
+        instance_id (str): Unique identifier for the instance
+        instance_data (dict): The instance data to store in the metaadata.
+    """
+    set_instances({instance_id: instance_data}, update=update)
+
+
+def set_instances(instance_data_by_id, update=False):
+    """Store data for multiple instances at the same time.
+
+    Args:
+        instance_data_by_id (dict): instance data queried by id
+        update (bool, optional): whether the data needs update.
+            Defaults to False.
+    """
+    instances = parsing_sd_data(AYON_METADATA_INSTANCES_KEY) or {}
+    for instance_id, instance_data in instance_data_by_id.items():
+        if update:
+            existing_data = instances.get(instance_id, {})
+            existing_data.update(instance_data)
+        else:
+            instances[instance_id] = instance_data
+
+    set_sd_metadata(AYON_METADATA_INSTANCES_KEY, instances)
+
+
+def remove_instance(instance_id):
+    """Helper method to remove the data for a specific container"""
+    instances = parsing_sd_data(AYON_METADATA_INSTANCES_KEY) or {}
+    instances.pop(instance_id, None)
+    set_sd_metadata(AYON_METADATA_INSTANCES_KEY, instances)
+
+
+def get_instances():
+    """Return all instances stored in the project instances as a list"""
+    get_instances_by_id = parsing_sd_data(AYON_METADATA_INSTANCES_KEY) or {}
+    return list(get_instances_by_id.values())

--- a/client/ayon_substancedesigner/api/pipeline.py
+++ b/client/ayon_substancedesigner/api/pipeline.py
@@ -2,7 +2,6 @@
 """Pipeline tools for Ayon Substance Designer integration."""
 import os
 import logging
-from functools import partial
 
 # Substance 3D Designer modules
 import sd

--- a/client/ayon_substancedesigner/api/pipeline.py
+++ b/client/ayon_substancedesigner/api/pipeline.py
@@ -14,8 +14,7 @@ from ayon_core.host import HostBase, IWorkfileHost, ILoadHost, IPublishHost
 from ayon_core.pipeline import (
     register_creator_plugin_path,
     register_loader_plugin_path,
-    AVALON_CONTAINER_ID,
-    get_current_context
+    AVALON_CONTAINER_ID
 )
 from ayon_core.settings import get_current_project_settings
 from ayon_core.pipeline.context_tools import version_up_current_workfile
@@ -137,18 +136,6 @@ class SubstanceDesignerHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         project_settings = get_current_project_settings()
         tab_menu_label = os.environ.get("AYON_MENU_LABEL") or "AYON"
         menu = qt_ui.newMenu(menuTitle=tab_menu_label, objectName=tab_menu_label)
-
-        # Add current context label
-        def _set_current_context_label(action):
-            context = get_current_context()
-            label = "{0[folder_path]}, {0[task_name]}".format(context)
-            action.setText(label)
-
-        action = menu.addAction("Current Context")
-        action.setEnabled(False)
-        # Update context label on menu show
-        menu.aboutToShow.connect(partial(_set_current_context_label, action))
-        menu.addSeparator()
 
         action = menu.addAction("Create...")
         action.triggered.connect(

--- a/client/ayon_substancedesigner/api/pipeline.py
+++ b/client/ayon_substancedesigner/api/pipeline.py
@@ -192,7 +192,6 @@ class SubstanceDesignerHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
     def _uninstall_menu(self):
         if self.menu:
-            # self.menu.destroy()
             tab_menu_label = os.environ.get("AYON_MENU_LABEL") or "AYON"
             ctx = sd.getContext()
             sd_app = ctx.getSDApplication()
@@ -200,6 +199,8 @@ class SubstanceDesignerHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             # Delete the menu
             if ui_mgr.findMenuFromObjectName() == tab_menu_label:
                 ui_mgr.deleteMenu(objectName=tab_menu_label)
+
+            self.menu.destroy()
 
         self.menu = None
 
@@ -271,25 +272,36 @@ def set_instances(instance_data_by_id, update=False):
         update (bool, optional): whether the data needs update.
             Defaults to False.
     """
-    instances = parsing_sd_data(AYON_METADATA_INSTANCES_KEY) or {}
-    for instance_id, instance_data in instance_data_by_id.items():
-        if update:
-            existing_data = instances.get(instance_id, {})
-            existing_data.update(instance_data)
-        else:
-            instances[instance_id] = instance_data
+    current_package = get_package_from_current_graph()
+    if current_package:
+        instances = parsing_sd_data(
+            current_package, AYON_METADATA_INSTANCES_KEY) or {}
+        for instance_id, instance_data in instance_data_by_id.items():
+            if update:
+                existing_data = instances.get(instance_id, {})
+                existing_data.update(instance_data)
+            else:
+                instances[instance_id] = instance_data
 
-    set_sd_metadata(AYON_METADATA_INSTANCES_KEY, instances)
+        set_sd_metadata(AYON_METADATA_INSTANCES_KEY, instances)
 
 
 def remove_instance(instance_id):
     """Helper method to remove the data for a specific container"""
-    instances = parsing_sd_data(AYON_METADATA_INSTANCES_KEY) or {}
-    instances.pop(instance_id, None)
-    set_sd_metadata(AYON_METADATA_INSTANCES_KEY, instances)
+    current_package = get_package_from_current_graph()
+    if current_package:
+        instances = parsing_sd_data(
+            current_package, AYON_METADATA_INSTANCES_KEY) or {}
+        instances.pop(instance_id, None)
+        set_sd_metadata(AYON_METADATA_INSTANCES_KEY, instances)
 
 
 def get_instances():
     """Return all instances stored in the project instances as a list"""
-    get_instances_by_id = parsing_sd_data(AYON_METADATA_INSTANCES_KEY) or {}
+    current_package = get_package_from_current_graph()
+    if not current_package:
+        return []
+
+    get_instances_by_id = parsing_sd_data(
+        current_package, AYON_METADATA_INSTANCES_KEY) or {}
     return list(get_instances_by_id.values())

--- a/client/ayon_substancedesigner/api/pipeline.py
+++ b/client/ayon_substancedesigner/api/pipeline.py
@@ -221,7 +221,7 @@ def imprint(current_package, name, namespace, context, loader, identifier, optio
         "objectName": identifier
     }
     if options:
-        for key, value in options:
+        for key, value in options.items():
             data[key] = value
     container_data = parsing_sd_data(
         current_package, AYON_METADATA_CONTAINERS_KEY, is_dictionary=False)

--- a/client/ayon_substancedesigner/deploy/ayon_plugin.py
+++ b/client/ayon_substancedesigner/deploy/ayon_plugin.py
@@ -1,0 +1,15 @@
+
+
+def initializeSDPlugin():
+    from ayon_core.pipeline import install_host
+    from ayon_substancedesigner.api import SubstanceDesignerHost
+    install_host(SubstanceDesignerHost())
+
+
+def uninitializeSDPlugin():
+    from ayon_core.pipeline import uninstall_host
+    uninstall_host()
+
+
+if __name__ == "__main__":
+    initializeSDPlugin()

--- a/client/ayon_substancedesigner/plugins/create/create_textures.py
+++ b/client/ayon_substancedesigner/plugins/create/create_textures.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""Creator plugin for creating textures."""
+from ayon_core.pipeline import CreatedInstance, Creator, CreatorError
+from ayon_core.lib import BoolDef, EnumDef
+
+from ayon_substancedesigner.api.pipeline import (
+    get_instances,
+    set_instance,
+    set_instances,
+    remove_instance
+)
+from ayon_substancedesigner.api.lib import get_current_graph_name
+
+
+class CreateTextures(Creator):
+    """Create a texture set."""
+    identifier = "io.ayon.creators.substancedesigner.textureset"
+    label = "Textures"
+    product_type = "textureSet"
+    icon = "picture-o"
+
+    default_variant = "Main"
+    settings_category = "substancedesigner"
+
+    def create(self, product_name, instance_data, pre_create_data):
+        current_graph_name = get_current_graph_name()
+        if not current_graph_name:
+            raise CreatorError("Can't create a Texture Set instance without "
+                               "the Substance Designer Graph.")
+        # Transfer settings from pre create to instance
+        creator_attributes = instance_data.setdefault(
+            "creator_attributes", dict())
+        for key in [
+            "review",
+            "sbsar",
+            "exportFileFormat",
+        ]:
+            if key in pre_create_data:
+                creator_attributes[key] = pre_create_data[key]
+
+        instance_data["graph_name"] = current_graph_name
+
+        instance = self.create_instance_in_context(product_name,
+                                                   instance_data)
+        set_instance(
+            instance_id=instance["instance_id"],
+            instance_data=instance.data_to_store()
+        )
+
+    def collect_instances(self):
+        for instance in get_instances():
+            if (instance.get("creator_identifier") == self.identifier or
+                    instance.get("productType") == self.product_type):
+                self.create_instance_in_context_from_existing(instance)
+
+    def update_instances(self, update_list):
+        instance_data_by_id = {}
+        for instance, _changes in update_list:
+            # Persist the data
+            instance_id = instance.get("instance_id")
+            instance_data = instance.data_to_store()
+            instance_data_by_id[instance_id] = instance_data
+        set_instances(instance_data_by_id, update=True)
+
+    def remove_instances(self, instances):
+        for instance in instances:
+            remove_instance(instance["instance_id"])
+            self._remove_instance_from_context(instance)
+
+    # Helper methods (this might get moved into Creator class)
+    def create_instance_in_context(self, product_name, data):
+        instance = CreatedInstance(
+            self.product_type, product_name, data, self
+        )
+        self.create_context.creator_adds_instance(instance)
+        return instance
+
+    def create_instance_in_context_from_existing(self, data):
+        instance = CreatedInstance.from_existing(data, self)
+        self.create_context.creator_adds_instance(instance)
+        return instance
+
+    def get_instance_attr_defs(self):
+        return [
+            BoolDef("review",
+                    label="Review",
+                    tooltip="Mark as reviewable",
+                    default=True),
+            BoolDef("sbsar",
+                    label="Export Sbsar",
+                    tooltip="Export Sbsar along with textures",
+                    default=False),
+            EnumDef("exportFileFormat",
+                    items={
+                        # TODO: Get available extensions from substance API
+                        "bmp": "bmp",
+                        "dds": "dds",
+                        "jpeg": "jpeg",
+                        "jpg": "jpg",
+                        "png": "png",
+                        "tga": "targa",
+                        "tif": "tiff",
+                        "surface": "surface",
+                        "hdr": "hdr",
+                        "exr": "exr",
+                        "jif": "jif",
+                        "jpe": "jpe",
+                        "webp": "webp",
+                        # TODO: File formats that combine the exported textures
+                        #   like psd are not correctly supported due to
+                        #   publishing only a single file
+                        # "sbsar": "sbsar",
+                    },
+                    default="png",
+                    label="File type")
+        ]

--- a/client/ayon_substancedesigner/plugins/create/create_workfile.py
+++ b/client/ayon_substancedesigner/plugins/create/create_workfile.py
@@ -10,8 +10,7 @@ from ayon_substancedesigner.api.pipeline import (
     set_instance,
     get_instances
 )
-
-import sd
+from ayon_substancedesigner.api.lib import get_package_from_current_graph
 
 
 class CreateWorkfile(AutoCreator):
@@ -25,16 +24,99 @@ class CreateWorkfile(AutoCreator):
     settings_category = "substancedesigner"
 
     def create(self):
-        pass
+        current_package = get_package_from_current_graph()
+        if not current_package:
+            return
+        variant = self.default_variant
+        project_name = self.project_name
+        folder_path = self.create_context.get_current_folder_path()
+        task_name = self.create_context.get_current_task_name()
+        host_name = self.create_context.host_name
+
+        # Workfile instance should always exist and must only exist once.
+        # As such we'll first check if it already exists and is collected.
+        current_instance = next(
+            (
+                instance for instance in self.create_context.instances
+                if instance.creator_identifier == self.identifier
+            ), None)
+
+        current_folder_path = None
+        if current_instance is not None:
+            current_folder_path = current_instance["folderPath"]
+
+        if current_instance is None:
+            self.log.info("Auto-creating workfile instance...")
+            folder_entity = ayon_api.get_folder_by_path(
+                project_name, folder_path
+            )
+            task_entity = ayon_api.get_task_by_name(
+                project_name, folder_entity["id"], task_name
+            )
+            product_name = self.get_product_name(
+                project_name,
+                folder_entity,
+                task_entity,
+                variant,
+                host_name,
+            )
+            data = {
+                "folderPath": folder_path,
+                "task": task_name,
+                "variant": variant
+            }
+            current_instance = self.create_instance_in_context(product_name,
+                                                               data)
+        elif (
+            current_folder_path != folder_path
+            or current_instance["task"] != task_name
+        ):
+            # Update instance context if is not the same
+            folder_entity = ayon_api.get_folder_by_path(
+                project_name, folder_path
+            )
+            task_entity = ayon_api.get_task_by_name(
+                project_name, folder_entity["id"], task_name
+            )
+            product_name = self.get_product_name(
+                project_name,
+                folder_entity,
+                task_entity,
+                variant,
+                host_name,
+            )
+            current_instance["folderPath"] = folder_path
+            current_instance["task"] = task_name
+            current_instance["productName"] = product_name
+
+        set_instance(
+            instance_id=current_instance.get("instance_id"),
+            instance_data=current_instance.data_to_store()
+        )
 
     def collect_instances(self):
-        pass
+        for instance in get_instances():
+            if (instance.get("creator_identifier") == self.identifier or
+                    instance.get("productType") == self.product_type):
+                self.create_instance_in_context_from_existing(instance)
 
     def update_instances(self, update_list):
-        pass
+        instance_data_by_id = {}
+        for instance, _changes in update_list:
+            # Persist the data
+            instance_id = instance.get("instance_id")
+            instance_data = instance.data_to_store()
+            instance_data_by_id[instance_id] = instance_data
+        set_instances(instance_data_by_id, update=True)
 
     def create_instance_in_context(self, product_name, data):
-        return None
+        instance = CreatedInstance(
+            self.product_type, product_name, data, self
+        )
+        self.create_context.creator_adds_instance(instance)
+        return instance
 
     def create_instance_in_context_from_existing(self, data):
-        return None
+        instance = CreatedInstance.from_existing(data, self)
+        self.create_context.creator_adds_instance(instance)
+        return instance

--- a/client/ayon_substancedesigner/plugins/create/create_workfile.py
+++ b/client/ayon_substancedesigner/plugins/create/create_workfile.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""Creator plugin for creating workfiles."""
+
+import ayon_api
+
+from ayon_core.pipeline import CreatedInstance, AutoCreator
+
+from ayon_substancedesigner.api.pipeline import (
+    set_instances,
+    set_instance,
+    get_instances
+)
+
+import sd
+
+
+class CreateWorkfile(AutoCreator):
+    """Workfile auto-creator."""
+    identifier = "io.ayon.creators.substancedesigner.workfile"
+    label = "Workfile"
+    product_type = "workfile"
+    icon = "document"
+
+    default_variant = "Main"
+    settings_category = "substancedesigner"
+
+    def create(self):
+        pass
+
+    def collect_instances(self):
+        pass
+
+    def update_instances(self, update_list):
+        pass
+
+    def create_instance_in_context(self, product_name, data):
+        return None
+
+    def create_instance_in_context_from_existing(self, data):
+        return None

--- a/client/ayon_substancedesigner/plugins/load/load_texture.py
+++ b/client/ayon_substancedesigner/plugins/load/load_texture.py
@@ -1,25 +1,100 @@
+import os
+import sd
+from ayon_core.pipeline import load
 
-from ayon_core.pipeline import (
-    load
-)
+from ayon_core.lib import EnumDef
 from ayon_substancedesigner.api.pipeline import imprint
+from ayon_substancedesigner.api.lib import get_package_from_current_graph
+
+
+def has_resource_file(current_package):
+    for resource in current_package.getChildrenResources(True):
+        if resource.getClassName() == "SDResourceFolder":
+            return True
+    return False
+
+
+def get_resource_folder(current_package):
+    for resource in current_package.getChildrenResources(True):
+        if resource.getClassName() == "SDResourceFolder":
+            return resource
+
 
 class SubstanceLoadProjectImage(load.LoaderPlugin):
-    """Load Image for project"""
+    """Load Texture for project"""
 
     product_types = {"image", "textures"}
     representations = {"*"}
 
-    label = "Load Image For Project Creation"
+    label = "Load Texture"
     order = -10
     icon = "code-fork"
     color = "orange"
 
-    def load(self, context, name, namespace, options=None):
-        pass
+
+    @classmethod
+    def get_options(cls, contexts):
+        return [
+            EnumDef(
+                    "resource_loading_options",
+                    label="Resource Loading Options",
+                    items={
+                        1: "Linked",
+                        2: "CopiedAndLinked",
+                        3: "BinaryEmbedded",
+                    },
+                    default=1
+            ),
+        ]
+
+
+    def load(self, context, name, namespace, options):
+        current_package = get_package_from_current_graph()
+        filepath = self.filepath_from_context(context)
+        resource_embed_method = options.get("resource_loading_options", 1)
+        filename = self.import_texture(
+            filepath, context, current_package, resource_embed_method)
+        imprint(
+            current_package, name, namespace,
+            context, loader=self, identifier=filename,
+            options=options
+        )
 
     def update(self, container, context):
-        pass
+        # As the filepath for SD Resource file is read-only data.
+        # the update function cannot directly set the textures
+        # accordingly to the versions in the existing SD Resource
+        # Therefore, new resource version of the bitmap would be
+        # created when updating
+        current_package = get_package_from_current_graph()
+        filepath = self.filepath_from_context(context)
+        resource_embed_method = int(container["resource_loading_options"])
+        options = {
+            "resource_loading_options": resource_embed_method
+        }
+        filename = self.import_texture(
+            filepath, context, current_package, resource_embed_method)
+        imprint(
+            current_package, container["name"], container.get("namespace", ""),
+            context, loader=self, identifier=filename,
+            options=options
+        )
+
 
     def remove(self, container):
         pass
+
+    def import_texture(self, filepath, context, current_package, resource_embed_method):
+        project_name = context["project"]["name"]
+        filename = os.path.basename(filepath)
+        if not has_resource_file(current_package):
+            resource_folder = sd.api.sdresourcefolder.SDResourceFolder.sNew(current_package)
+            resource_folder.setIdentifier(f"{project_name}_rosources")
+        else:
+            resource_folder = get_resource_folder(current_package)
+        bitmap_resource = sd.api.sdresourcebitmap.SDResourceBitmap.sNewFromFile(
+            resource_folder, filepath,
+            sd.api.sdresource.EmbedMethod(resource_embed_method)
+        )
+        bitmap_resource.setIdentifier(filename)
+        return filename

--- a/client/ayon_substancedesigner/plugins/load/load_texture.py
+++ b/client/ayon_substancedesigner/plugins/load/load_texture.py
@@ -1,0 +1,25 @@
+
+from ayon_core.pipeline import (
+    load
+)
+from ayon_substancedesigner.api.pipeline import imprint
+
+class SubstanceLoadProjectImage(load.LoaderPlugin):
+    """Load Image for project"""
+
+    product_types = {"image", "textures"}
+    representations = {"*"}
+
+    label = "Load Image For Project Creation"
+    order = -10
+    icon = "code-fork"
+    color = "orange"
+
+    def load(self, context, name, namespace, options=None):
+        pass
+
+    def update(self, container, context):
+        pass
+
+    def remove(self, container):
+        pass

--- a/client/ayon_substancedesigner/plugins/load/load_texture.py
+++ b/client/ayon_substancedesigner/plugins/load/load_texture.py
@@ -106,7 +106,8 @@ class SubstanceLoadProjectImage(load.LoaderPlugin):
         # container data taking correct identifier value
         identifier = filename.replace(".", "_")
         if not has_resource_file(current_package):
-            resource_folder = sd.api.sdresourcefolder.SDResourceFolder.sNew(current_package)
+            resource_folder = sd.api.sdresourcefolder.SDResourceFolder.sNew(
+                current_package)
             resource_folder.setIdentifier(f"{project_name}_rosources")
         else:
             resource_folder = get_resource_folder(current_package)

--- a/client/ayon_substancedesigner/plugins/load/load_texture.py
+++ b/client/ayon_substancedesigner/plugins/load/load_texture.py
@@ -3,7 +3,10 @@ import sd
 from ayon_core.pipeline import load
 
 from ayon_core.lib import EnumDef
-from ayon_substancedesigner.api.pipeline import imprint, remove_container_metadata
+from ayon_substancedesigner.api.pipeline import (
+    imprint,
+    remove_container_metadata
+)
 from ayon_substancedesigner.api.lib import get_package_from_current_graph
 
 
@@ -77,8 +80,12 @@ class SubstanceLoadProjectImage(load.LoaderPlugin):
         identifier = self.import_texture(
             filepath, context, current_package, resource_embed_method)
         imprint(
-            current_package, container["name"], container.get("namespace", None),
-            context, loader=self, identifier=identifier,
+            current_package,
+            container["name"],
+            container.get("namespace", None),
+            context,
+            loader=self,
+            identifier=identifier,
             options=options
         )
 
@@ -91,7 +98,8 @@ class SubstanceLoadProjectImage(load.LoaderPlugin):
                     resource.delete()
         remove_container_metadata(container)
 
-    def import_texture(self, filepath, context, current_package, resource_embed_method):
+    def import_texture(self, filepath, context,
+                       current_package, resource_embed_method):
         project_name = context["project"]["name"]
         filename = os.path.splitext(os.path.basename(filepath))[0]
         # identifier would convert "." to "_", this makes sure
@@ -102,7 +110,7 @@ class SubstanceLoadProjectImage(load.LoaderPlugin):
             resource_folder.setIdentifier(f"{project_name}_rosources")
         else:
             resource_folder = get_resource_folder(current_package)
-        bitmap_resource = sd.api.sdresourcebitmap.SDResourceBitmap.sNewFromFile(
+        bitmap_resource = sd.api.sdresourcebitmap.SDResourceBitmap.sNewFromFile(                # noqa
             resource_folder, filepath,
             sd.api.sdresource.EmbedMethod(resource_embed_method)
         )

--- a/client/ayon_substancedesigner/plugins/load/load_texture.py
+++ b/client/ayon_substancedesigner/plugins/load/load_texture.py
@@ -51,12 +51,15 @@ class SubstanceLoadProjectImage(load.LoaderPlugin):
         current_package = get_package_from_current_graph()
         filepath = self.filepath_from_context(context)
         resource_embed_method = options.get("resource_loading_options", 1)
+        import_options = {
+            "resource_loading_options": resource_embed_method
+        }
         identifier = self.import_texture(
             filepath, context, current_package, resource_embed_method)
         imprint(
             current_package, name, namespace,
             context, loader=self, identifier=identifier,
-            options=options
+            options=import_options
         )
 
     def update(self, container, context):

--- a/client/ayon_substancedesigner/plugins/load/load_texture.py
+++ b/client/ayon_substancedesigner/plugins/load/load_texture.py
@@ -47,7 +47,6 @@ class SubstanceLoadProjectImage(load.LoaderPlugin):
             ),
         ]
 
-
     def load(self, context, name, namespace, options):
         current_package = get_package_from_current_graph()
         filepath = self.filepath_from_context(context)
@@ -105,4 +104,5 @@ class SubstanceLoadProjectImage(load.LoaderPlugin):
             sd.api.sdresource.EmbedMethod(resource_embed_method)
         )
         bitmap_resource.setIdentifier(identifier)
+
         return identifier

--- a/client/ayon_substancedesigner/plugins/publish/collect_current_file.py
+++ b/client/ayon_substancedesigner/plugins/publish/collect_current_file.py
@@ -1,0 +1,20 @@
+import pyblish.api
+
+from ayon_core.pipeline import registered_host
+
+
+class CollectCurrentFile(pyblish.api.ContextPlugin):
+    """Inject the current working file into context"""
+
+    order = pyblish.api.CollectorOrder - 0.49
+    label = "Current Workfile"
+    hosts = ["substancedesigner"]
+
+    def process(self, context):
+        host = registered_host()
+        path = host.get_current_workfile()
+        if not path:
+            self.log.error("Scene is not saved.")
+
+        context.data["currentFile"] = path
+        self.log.debug(f"Current workfile: {path}")

--- a/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
@@ -1,0 +1,141 @@
+import copy
+
+import pyblish.api
+import ayon_api
+
+from ayon_core.pipeline import tempdir
+
+from ayon_core.pipeline.create import get_product_name
+from ayon_substancedesigner.api.lib import (
+    get_map_identifiers_by_graph,
+)
+
+
+class CollectTextureSet(pyblish.api.InstancePlugin):
+    """Extract Textures using an output template config"""
+
+    label = "Collect Texture Set images"
+    hosts = ["substancedesigner"]
+    families = ["textureSet"]
+    order = pyblish.api.CollectorOrder + 0.01
+
+    def process(self, instance):
+        graph_name = instance.data["graph_name"]
+        map_identifiers = get_map_identifiers_by_graph(graph_name)
+        project_name = instance.context.data["projectName"]
+        folder_entity = ayon_api.get_folder_by_path(
+            project_name,
+            instance.data["folderPath"]
+        )
+        task_name = instance.data.get("task")
+        task_entity = None
+        if folder_entity and task_name:
+            task_entity = ayon_api.get_task_by_name(
+                project_name, folder_entity["id"], task_name
+            )
+        for map_identifier in map_identifiers:
+            self.create_image_instance(
+                instance, task_entity, graph_name, map_identifier)
+
+    def create_image_instance(self, instance, task_entity,
+                              graph_name, map_identifier):
+        """Create a new instance per image.
+
+        The new instances will be of product type `image`.
+
+        """
+
+        context = instance.context
+        # Always include the map identifier
+        texture_set_name = f"{graph_name}_{map_identifier}"
+
+        task_name = task_type = None
+        if task_entity:
+            task_name = task_entity["name"]
+            task_type = task_entity["taskType"]
+
+        # TODO: The product type actually isn't 'texture' currently but
+        #   for now this is only done so the product name starts with
+        #   'texture'
+        image_product_name = get_product_name(
+            context.data["projectName"],
+            task_name,
+            task_type,
+            context.data["hostName"],
+            product_type="texture",
+            variant=instance.data["variant"] + texture_set_name,
+            project_settings=context.data["project_settings"]
+        )
+        image_product_group_name = get_product_name(
+            context.data["projectName"],
+            task_name,
+            task_type,
+            context.data["hostName"],
+            product_type="texture",
+            variant=instance.data["variant"],
+            project_settings=context.data["project_settings"]
+        )
+        ext = instance.data["exportFileFormat"]
+        # Prepare representation
+        representation = {
+            "name": ext.lstrip("."),
+            "ext": ext.lstrip("."),
+            "files": f"{texture_set_name}.{ext}",
+        }
+        # Set up the representation for thumbnail generation
+        staging_dir = tempdir.get_temp_dir(
+            instance.context.data["projectName"],
+            use_local_temp=True
+        )
+        representation["tags"] = ["review"]
+        representation["stagingDir"] = staging_dir
+        # Clone the instance
+        product_type = "image"
+        image_instance = context.create_instance(image_product_name)
+        image_instance[:] = instance[:]
+        image_instance.data.update(copy.deepcopy(dict(instance.data)))
+        image_instance.data["name"] = image_product_name
+        image_instance.data["label"] = image_product_name
+        image_instance.data["productName"] = image_product_name
+        image_instance.data["productType"] = product_type
+        image_instance.data["family"] = product_type
+        image_instance.data["families"] = [product_type, "textures"]
+        if instance.data["creator_attributes"].get("review"):
+            image_instance.data["families"].append("review")
+
+        image_instance.data["representations"] = [representation]
+
+        # Group the textures together in the loader
+        image_instance.data["productGroup"] = image_product_group_name
+
+        # Store the texture set name and stack name on the instance
+        image_instance.data["textureSetName"] = texture_set_name
+
+        # Store the instance in the original instance as a member
+        instance.append(image_instance)
+
+
+class CollectTextureSetStagingDir(pyblish.api.InstancePlugin):
+    """Set the staging directory for the `textureSet` instance taking into
+    account custom staging dirs. Propagate this custom staging dir to the
+    individual texture image instances that are created from the textureSet"""
+
+    label = "Texture Set Staging Dir"
+    hosts = ["substancedesigner"]
+    families = ["textureSet"]
+
+    # Run after CollectManagedStagingDir
+    order = pyblish.api.CollectorOrder + 0.4991
+
+    def process(self, instance):
+
+        staging_dir = instance.data["stagingDir"]
+        # Update image instances and their representations
+        for image_instance in instance:
+
+            # Include the updated config
+            image_instance.data["stagingDir"] = staging_dir
+
+            # Update representation staging dir.
+            for repre in image_instance.data["representations"]:
+                repre["stagingDir"] = staging_dir

--- a/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
@@ -40,6 +40,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         instance.data["map_identifiers"] = map_identifiers
         # if sbsar sets to True, it would enable to export sbsar
         if instance.data["creator_attributes"].get("sbsar", False):
+            self.log.debug("Adding SBSAR families.")
             instance.data["families"].append("sbsar")
 
         for map_identifier in map_identifiers:

--- a/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
@@ -37,6 +37,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             instance.context.data["projectName"],
             use_local_temp=True
         )
+        instance.data["map_identifiers"] = map_identifiers
         for map_identifier in map_identifiers:
             self.create_image_instance(
                 instance, task_entity, graph_name, map_identifier,

--- a/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
@@ -38,14 +38,14 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             use_local_temp=True
         )
         instance.data["map_identifiers"] = map_identifiers
+        # if sbsar sets to True, it would enable to export sbsar
+        if instance.data["creator_attributes"].get("sbsar", False):
+            instance.data["families"] += "sbsar"
+
         for map_identifier in map_identifiers:
             self.create_image_instance(
                 instance, task_entity, graph_name, map_identifier,
                 staging_dir)
-
-        # if sbsar sets to True, it would enable to export sbsar
-        if instance.data.get("sbsar"):
-            instance.data["families"] += "sbsar"
 
     def create_image_instance(self, instance, task_entity,
                               graph_name, map_identifier,

--- a/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
@@ -74,7 +74,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             task_type,
             context.data["hostName"],
             product_type="texture",
-            variant=instance.data["variant"] + texture_set_name,
+            variant=instance.data["variant"] + f"_{map_identifier}",
             project_settings=context.data["project_settings"]
         )
         image_product_group_name = get_product_name(

--- a/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
@@ -33,16 +33,22 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             task_entity = ayon_api.get_task_by_name(
                 project_name, folder_entity["id"], task_name
             )
+        staging_dir = tempdir.get_temp_dir(
+            instance.context.data["projectName"],
+            use_local_temp=True
+        )
         for map_identifier in map_identifiers:
             self.create_image_instance(
-                instance, task_entity, graph_name, map_identifier)
+                instance, task_entity, graph_name, map_identifier,
+                staging_dir)
 
         # if sbsar sets to True, it would enable to export sbsar
         if instance.data.get("sbsar"):
             instance.data["families"] += "sbsar"
 
     def create_image_instance(self, instance, task_entity,
-                              graph_name, map_identifier):
+                              graph_name, map_identifier,
+                              staging_dir):
         """Create a new instance per image.
 
         The new instances will be of product type `image`.
@@ -79,7 +85,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             variant=instance.data["variant"],
             project_settings=context.data["project_settings"]
         )
-        ext = instance.data["exportFileFormat"]
+        ext = instance.data["creator_attributes"].get("exportFileFormat")
         # Prepare representation
         representation = {
             "name": ext.lstrip("."),
@@ -87,10 +93,6 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             "files": f"{texture_set_name}.{ext}",
         }
         # Set up the representation for thumbnail generation
-        staging_dir = tempdir.get_temp_dir(
-            instance.context.data["projectName"],
-            use_local_temp=True
-        )
         representation["tags"] = ["review"]
         representation["stagingDir"] = staging_dir
         # Clone the instance
@@ -134,6 +136,7 @@ class CollectTextureSetStagingDir(pyblish.api.InstancePlugin):
     def process(self, instance):
 
         staging_dir = instance.data["stagingDir"]
+        self.log.debug(staging_dir)
         # Update image instances and their representations
         for image_instance in instance:
 

--- a/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
@@ -37,6 +37,10 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             self.create_image_instance(
                 instance, task_entity, graph_name, map_identifier)
 
+        # if sbsar sets to True, it would enable to export sbsar
+        if instance.data.get("sbsar"):
+            instance.data["families"] += "sbsar"
+
     def create_image_instance(self, instance, task_entity,
                               graph_name, map_identifier):
         """Create a new instance per image.

--- a/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
@@ -40,7 +40,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         instance.data["map_identifiers"] = map_identifiers
         # if sbsar sets to True, it would enable to export sbsar
         if instance.data["creator_attributes"].get("sbsar", False):
-            instance.data["families"] += "sbsar"
+            instance.data["families"].append("sbsar")
 
         for map_identifier in map_identifiers:
             self.create_image_instance(

--- a/client/ayon_substancedesigner/plugins/publish/collect_workfile_representation.py
+++ b/client/ayon_substancedesigner/plugins/publish/collect_workfile_representation.py
@@ -1,0 +1,30 @@
+import os
+import pyblish.api
+
+
+class CollectWorkfileRepresentation(pyblish.api.InstancePlugin):
+    """Create a publish representation for the current workfile instance."""
+
+    order = pyblish.api.CollectorOrder
+    label = "Workfile representation"
+    hosts = ["substancedesigner"]
+    families = ["workfile"]
+
+    def process(self, instance):
+
+        context = instance.context
+        current_file = context.data.get("currentFile")
+        if not current_file:
+            self.log.error("Current file is not saved. File could not be "
+                           "collected as workfile representation.")
+            return
+
+        folder, file = os.path.split(current_file)
+        filename, ext = os.path.splitext(file)
+
+        instance.data["representations"] = [{
+            "name": ext.lstrip("."),
+            "ext": ext.lstrip("."),
+            "files": file,
+            "stagingDir": folder,
+        }]

--- a/client/ayon_substancedesigner/plugins/publish/extract_sbsar.py
+++ b/client/ayon_substancedesigner/plugins/publish/extract_sbsar.py
@@ -18,6 +18,7 @@ class ExtractSbsar(publish.Extractor):
     order = publish.Extractor.order - 0.11
 
     def process(self, instance):
+        self.log.debug("Extracting SBSAR...")
         ctx = sd.getContext()
         exporterInstance = SDSBSARExporter(ctx, None)
         exporter = exporterInstance.sNew()

--- a/client/ayon_substancedesigner/plugins/publish/extract_sbsar.py
+++ b/client/ayon_substancedesigner/plugins/publish/extract_sbsar.py
@@ -15,10 +15,9 @@ class ExtractSbsar(publish.Extractor):
     hosts = ["substancedesigner"]
     families = ["sbsar"]
 
-    order = publish.Extractor.order - 0.11
+    order = publish.Extractor.order - 0.099
 
     def process(self, instance):
-        self.log.debug("Extracting SBSAR...")
         ctx = sd.getContext()
         exporterInstance = SDSBSARExporter(ctx, None)
         exporter = exporterInstance.sNew()

--- a/client/ayon_substancedesigner/plugins/publish/extract_sbsar.py
+++ b/client/ayon_substancedesigner/plugins/publish/extract_sbsar.py
@@ -6,7 +6,6 @@ from ayon_substancedesigner.api.lib import get_sd_graph_by_name
 from sd.api.sbs.sdsbsarexporter import SDSBSARExporter
 
 
-
 class ExtractSbsar(publish.Extractor):
     """Extract SBSAR
 

--- a/client/ayon_substancedesigner/plugins/publish/extract_sbsar.py
+++ b/client/ayon_substancedesigner/plugins/publish/extract_sbsar.py
@@ -16,7 +16,7 @@ class ExtractSbsar(publish.Extractor):
     hosts = ["substancedesigner"]
     families = ["sbsar"]
 
-    order = publish.Extractor.order - 0.099
+    order = publish.Extractor.order - 0.11
 
     def process(self, instance):
         ctx = sd.getContext()
@@ -30,8 +30,9 @@ class ExtractSbsar(publish.Extractor):
         filename = os.path.basename(current_file)
         filename = filename.replace("sbs", "sbsar")
         staging_dir = self.staging_dir(instance)
+        sbsar_staging_dir = os.path.join(staging_dir, "sbsar")
         filepath = os.path.normpath(
-            os.path.join(staging_dir, filename))
+            os.path.join(sbsar_staging_dir, filename))
 
         # export the graph with filepath
         exporter.exportPackageToSBSAR(sd_graph, filepath)
@@ -40,7 +41,7 @@ class ExtractSbsar(publish.Extractor):
             'name': 'sbsar',
             'ext': 'sbsar',
             'files': filename,
-            "stagingDir": staging_dir,
+            "stagingDir": sbsar_staging_dir,
         }
 
         instance.data["representations"].append(representation)

--- a/client/ayon_substancedesigner/plugins/publish/extract_sbsar.py
+++ b/client/ayon_substancedesigner/plugins/publish/extract_sbsar.py
@@ -1,7 +1,7 @@
 import os
 import sd
 
-from ayon_core.pipeline import KnownPublishError, publish
+from ayon_core.pipeline import publish
 from ayon_substancedesigner.api.lib import get_sd_graph_by_name
 from sd.api.sbs.sdsbsarexporter import SDSBSARExporter
 

--- a/client/ayon_substancedesigner/plugins/publish/extract_sbsar.py
+++ b/client/ayon_substancedesigner/plugins/publish/extract_sbsar.py
@@ -1,0 +1,46 @@
+import os
+import sd
+
+from ayon_core.pipeline import KnownPublishError, publish
+from ayon_substancedesigner.api.lib import get_sd_graph_by_name
+from sd.api.sbs.sdsbsarexporter import SDSBSARExporter
+
+
+
+class ExtractSbsar(publish.Extractor):
+    """Extract SBSAR
+
+    """
+
+    label = "Extract SBSAR"
+    hosts = ["substancedesigner"]
+    families = ["sbsar"]
+
+    order = publish.Extractor.order - 0.099
+
+    def process(self, instance):
+        ctx = sd.getContext()
+        exporterInstance = SDSBSARExporter(ctx, None)
+        exporter = exporterInstance.sNew()
+
+        graph_name = instance.data["graph_name"]
+        sd_graph = get_sd_graph_by_name(graph_name)
+
+        current_file = instance.context.data["currentFile"]
+        filename = os.path.basename(current_file)
+        filename = filename.replace("sbs", "sbsar")
+        staging_dir = self.staging_dir(instance)
+        filepath = os.path.normpath(
+            os.path.join(staging_dir, filename))
+
+        # export the graph with filepath
+        exporter.exportPackageToSBSAR(sd_graph, filepath)
+
+        representation = {
+            'name': 'sbsar',
+            'ext': 'sbsar',
+            'files': filename,
+            "stagingDir": staging_dir,
+        }
+
+        instance.data["representations"].append(representation)

--- a/client/ayon_substancedesigner/plugins/publish/extract_textures.py
+++ b/client/ayon_substancedesigner/plugins/publish/extract_textures.py
@@ -32,10 +32,16 @@ class ExtractTextures(publish.Extractor):
                     graph_name)
             )
         map_identifiers = instance.data["map_identifiers"]
-        for file, identifier in zip(os.listdir(staging_dir), map_identifiers):
+        # Rename the directories accordingly to the output maps
+        file_list_in_staging = [
+            path for path in os.listdir(staging_dir) if os.path.isfile(
+                os.path.join(staging_dir, path))
+        ]
+        for file, identifier in zip(file_list_in_staging, map_identifiers):
             src = os.path.join(staging_dir, file)
             dst = os.path.join(staging_dir, f"{graph_name}_{identifier}.{extension}")
             os.rename(src, dst)
+
         self.log.debug(f"Extracting to {staging_dir}")
         # The TextureSet instance should not be integrated. It generates no
         # output data. Instead the separated texture instances are generated

--- a/client/ayon_substancedesigner/plugins/publish/extract_textures.py
+++ b/client/ayon_substancedesigner/plugins/publish/extract_textures.py
@@ -21,7 +21,7 @@ class ExtractTextures(publish.Extractor):
         target_sd_graph = get_sd_graph_by_name(graph_name)
 
         staging_dir = self.staging_dir(instance)
-        extension = instance.data["exportFileFormat"]
+        extension = instance.data["creator_attributes"].get("exportFileFormat")
 
         result = export.exportSDGraphOutputs(
             target_sd_graph, staging_dir, extension)

--- a/client/ayon_substancedesigner/plugins/publish/extract_textures.py
+++ b/client/ayon_substancedesigner/plugins/publish/extract_textures.py
@@ -1,0 +1,37 @@
+import sd.tools.export as export
+from ayon_core.pipeline import KnownPublishError, publish
+from ayon_substancedesigner.api.lib import get_sd_graph_by_name
+
+
+
+class ExtractTextures(publish.Extractor):
+    """Extract Textures as Graph Outputs
+
+    """
+
+    label = "Extract Textures as Graph Outputs"
+    hosts = ["substancedesigner"]
+    families = ["textureSet"]
+
+    # Run before thumbnail extractors
+    order = publish.Extractor.order - 0.1
+
+    def process(self, instance):
+        graph_name = instance.data["graph_name"]
+        target_sd_graph = get_sd_graph_by_name(graph_name)
+
+        staging_dir = instance.data["stagingDir"]
+        extension = instance.data["exportFileFormat"]
+
+        result = export.exportSDGraphOutputs(
+            target_sd_graph, staging_dir, extension)
+        if not result:
+            raise KnownPublishError(
+                "Failed to export texture output in graph: {}".format(
+                    graph_name)
+            )
+
+        # The TextureSet instance should not be integrated. It generates no
+        # output data. Instead the separated texture instances are generated
+        # from it which themselves integrate into the database.
+        instance.data["integrate"] = False

--- a/client/ayon_substancedesigner/plugins/publish/extract_textures.py
+++ b/client/ayon_substancedesigner/plugins/publish/extract_textures.py
@@ -1,3 +1,4 @@
+import os
 import sd.tools.export as export
 from ayon_core.pipeline import KnownPublishError, publish
 from ayon_substancedesigner.api.lib import get_sd_graph_by_name
@@ -30,7 +31,12 @@ class ExtractTextures(publish.Extractor):
                 "Failed to export texture output in graph: {}".format(
                     graph_name)
             )
-
+        map_identifiers = instance.data["map_identifiers"]
+        for file, identifier in zip(os.listdir(staging_dir), map_identifiers):
+            src = os.path.join(staging_dir, file)
+            dst = os.path.join(staging_dir, f"{graph_name}_{identifier}.{extension}")
+            os.rename(src, dst)
+        self.log.debug(f"Extracting to {staging_dir}")
         # The TextureSet instance should not be integrated. It generates no
         # output data. Instead the separated texture instances are generated
         # from it which themselves integrate into the database.

--- a/client/ayon_substancedesigner/plugins/publish/extract_textures.py
+++ b/client/ayon_substancedesigner/plugins/publish/extract_textures.py
@@ -39,7 +39,8 @@ class ExtractTextures(publish.Extractor):
         ]
         for file, identifier in zip(file_list_in_staging, map_identifiers):
             src = os.path.join(staging_dir, file)
-            dst = os.path.join(staging_dir, f"{graph_name}_{identifier}.{extension}")
+            dst = os.path.join(staging_dir,
+                               f"{graph_name}_{identifier}.{extension}")
             os.rename(src, dst)
 
         self.log.debug(f"Extracting to {staging_dir}")

--- a/client/ayon_substancedesigner/plugins/publish/extract_textures.py
+++ b/client/ayon_substancedesigner/plugins/publish/extract_textures.py
@@ -20,7 +20,7 @@ class ExtractTextures(publish.Extractor):
         graph_name = instance.data["graph_name"]
         target_sd_graph = get_sd_graph_by_name(graph_name)
 
-        staging_dir = instance.data["stagingDir"]
+        staging_dir = self.staging_dir(instance)
         extension = instance.data["exportFileFormat"]
 
         result = export.exportSDGraphOutputs(

--- a/client/ayon_substancedesigner/plugins/publish/increment_workfile.py
+++ b/client/ayon_substancedesigner/plugins/publish/increment_workfile.py
@@ -1,0 +1,23 @@
+import pyblish.api
+
+from ayon_core.lib import version_up
+from ayon_core.pipeline import registered_host
+
+
+class IncrementWorkfileVersion(pyblish.api.ContextPlugin):
+    """Increment current workfile version."""
+
+    order = pyblish.api.IntegratorOrder + 1
+    label = "Increment Workfile Version"
+    optional = True
+    hosts = ["substancedesigner"]
+
+    def process(self, context):
+
+        assert all(result["success"] for result in context.data["results"]), (
+            "Publishing not successful so version is not increased.")
+
+        host = registered_host()
+        path = context.data["currentFile"]
+        self.log.info(f"Incrementing current workfile to: {path}")
+        host.save_workfile(version_up(path))

--- a/client/ayon_substancedesigner/plugins/publish/save_workfile.py
+++ b/client/ayon_substancedesigner/plugins/publish/save_workfile.py
@@ -22,7 +22,7 @@ class SaveCurrentWorkfile(pyblish.api.ContextPlugin):
 
         if host.workfile_has_unsaved_changes():
             self.log.info("Saving current file: {}".format(current))
-            host.save_workfile()
+            host.save_workfile(current)
         else:
             self.log.debug("Skipping workfile save because there are no "
                            "unsaved changes.")

--- a/client/ayon_substancedesigner/plugins/publish/save_workfile.py
+++ b/client/ayon_substancedesigner/plugins/publish/save_workfile.py
@@ -1,0 +1,28 @@
+import pyblish.api
+
+from ayon_core.pipeline import (
+    registered_host,
+    KnownPublishError
+)
+
+
+class SaveCurrentWorkfile(pyblish.api.ContextPlugin):
+    """Save current workfile"""
+
+    label = "Save current workfile"
+    order = pyblish.api.ExtractorOrder - 0.49
+    hosts = ["substancedesigner"]
+
+    def process(self, context):
+
+        host = registered_host()
+        current = host.get_current_workfile()
+        if context.data["currentFile"] != current:
+            raise KnownPublishError("Workfile has changed during publishing!")
+
+        if host.workfile_has_unsaved_changes():
+            self.log.info("Saving current file: {}".format(current))
+            host.save_workfile()
+        else:
+            self.log.debug("Skipping workfile save because there are no "
+                           "unsaved changes.")

--- a/client/ayon_substancedesigner/version.py
+++ b/client/ayon_substancedesigner/version.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+"""Package declaring AYON addon 'substancedesigner' version."""
+__version__ = "0.1.0+dev"

--- a/package.py
+++ b/package.py
@@ -6,7 +6,7 @@ name = "substancedesigner"
 title = "Substance Designer"
 
 # Required: Valid semantic version (https://semver.org/)
-version = "0.0.0"
+version = "0.1.0+dev"
 
 # Name of client code directory imported in AYON launcher
 # - do not specify if there is no client code

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -2,7 +2,7 @@ from typing import Type
 
 from ayon_server.addons import BaseServerAddon
 
-from .settings import SubstanceDesignerSettings, DEFAULT_SD_VALUES
+from .settings import SubstanceDesignerSettings, DEFAULT_SD_SETTINGS
 
 
 class SubstanceDesignerAddon(BaseServerAddon):
@@ -10,4 +10,4 @@ class SubstanceDesignerAddon(BaseServerAddon):
 
     async def get_default_settings(self):
         settings_model_cls = self.get_settings_model()
-        return settings_model_cls(**DEFAULT_SD_VALUES)
+        return settings_model_cls(**DEFAULT_SD_SETTINGS)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -2,12 +2,12 @@ from typing import Type
 
 from ayon_server.addons import BaseServerAddon
 
-from .settings import MySettings, DEFAULT_VALUES
+from .settings import SubstanceDesignerSettings, DEFAULT_SD_VALUES
 
 
-class MyAddon(BaseServerAddon):
-    settings_model: Type[MySettings] = MySettings
+class SubstanceDesignerAddon(BaseServerAddon):
+    settings_model: Type[SubstanceDesignerSettings] = SubstanceDesignerSettings
 
     async def get_default_settings(self):
         settings_model_cls = self.get_settings_model()
-        return settings_model_cls(**DEFAULT_VALUES)
+        return settings_model_cls(**DEFAULT_SD_VALUES)

--- a/server/settings.py
+++ b/server/settings.py
@@ -1,7 +1,0 @@
-from ayon_server.settings import BaseSettingsModel
-
-DEFAULT_SD_VALUES = {}
-
-
-class SubstanceDesignerSettings(BaseSettingsModel):
-    pass

--- a/server/settings.py
+++ b/server/settings.py
@@ -1,7 +1,7 @@
 from ayon_server.settings import BaseSettingsModel
 
-DEFAULT_VALUES = {}
+DEFAULT_SD_VALUES = {}
 
 
-class MySettings(BaseSettingsModel):
+class SubstanceDesignerSettings(BaseSettingsModel):
     pass

--- a/server/settings/__init__.py
+++ b/server/settings/__init__.py
@@ -1,0 +1,10 @@
+from .main import (
+    SubstanceDesignerSettings,
+    DEFAULT_SD_SETTINGS,
+)
+
+
+__all__ = (
+    "SubstanceDesignerSettings",
+    "DEFAULT_SD_SETTINGS",
+)

--- a/server/settings/imageio.py
+++ b/server/settings/imageio.py
@@ -1,0 +1,35 @@
+from ayon_server.settings import BaseSettingsModel, SettingsField
+
+
+class ImageIOFileRuleModel(BaseSettingsModel):
+    name: str = SettingsField("", title="Rule name")
+    pattern: str = SettingsField("", title="Regex pattern")
+    colorspace: str = SettingsField("", title="Colorspace name")
+    ext: str = SettingsField("", title="File extension")
+
+
+class ImageIOFileRulesModel(BaseSettingsModel):
+    activate_host_rules: bool = SettingsField(False)
+    rules: list[ImageIOFileRuleModel] = SettingsField(
+        default_factory=list,
+        title="Rules"
+    )
+
+
+class ImageIOSettings(BaseSettingsModel):
+    activate_host_color_management: bool = SettingsField(
+        True, title="Enable Color Management"
+    )
+    file_rules: ImageIOFileRulesModel = SettingsField(
+        default_factory=ImageIOFileRulesModel,
+        title="File Rules"
+    )
+
+
+DEFAULT_IMAGEIO_SETTINGS = {
+    "activate_host_color_management": True,
+    "file_rules": {
+        "activate_host_rules": False,
+        "rules": []
+    }
+}

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -1,0 +1,14 @@
+from ayon_server.settings import BaseSettingsModel, SettingsField
+from .imageio import ImageIOSettings, DEFAULT_IMAGEIO_SETTINGS
+
+
+class SubstanceDesignerSettings(BaseSettingsModel):
+    imageio: ImageIOSettings = SettingsField(
+        default_factory=ImageIOSettings,
+        title="Color Management (ImageIO)"
+    )
+
+
+DEFAULT_SD_SETTINGS = {
+    "imageio": DEFAULT_IMAGEIO_SETTINGS,
+}


### PR DESCRIPTION
## Changelog Description
Implementation of substance designer integration
- [x] Workfile Load/Save. Get current file etc.
- [x] Container data
- [x] Instance Data
- [x] Load Image(textures) for existing project
- [x] Publish Image(textures) -> (Part of the TextureSet product)
- [x] Publish Workfile
- [ ] Publish Sbsar (Can be part of the textureSet product)
- [ ] Callback to create Package Project for users

Maybe nice to have: 
- [ ] Load/Publish MDL
- [ ] Load/Publish custom graph node
- [ ] Publish textures/sbsar supporting for multiple graphs.

## Additional review information
Please test along with: https://github.com/ynput/ayon-applications/pull/50 and https://github.com/ynput/ayon-core/pull/1089
- Publishing colorspace data temporarily not supported in texture publish due to the limitation of the API
- Custom Pattern for output is not supported due to the limitation of the API

## Testing notes:
1. Build and install addon with this branch in the ayon server along with the updated application and core addons mentioned above
2. Launch Substance Designer
