### PR TITLE
Substance Designer: Refactoring Textures Product Type

### DIFF
--- a/client/ayon_substancedesigner/api/lib.py
+++ b/client/ayon_substancedesigner/api/lib.py
@@ -152,7 +152,8 @@ def parsing_sd_data(target_package, metadata_type: str, is_dictionary=True):
 def export_outputs_by_sd_graph(instance_name, target_graph, output_dir,
                                extension, selected_map_identifiers):
     """
-    Modified and referenced from Substance Designer exportSDGraphOutputs Python API.
+    Modified and referenced from exportSDGraphOutputs in Substance Designer
+    Python API.
     Export the textures from the output nodes of the specified SD Graphs
 
     Args:

--- a/client/ayon_substancedesigner/api/lib.py
+++ b/client/ayon_substancedesigner/api/lib.py
@@ -57,6 +57,21 @@ def get_current_graph_name():
     return current_graph.getIdentifier()
 
 
+def get_sd_graphs_by_package():
+    """Get Substance Designer Graphs by package
+
+    Returns:
+        list: name of Substance Designer Graphs
+    """
+    current_package = get_package_from_current_graph()
+    return [
+        resource.getIdentifier()
+        for resource in
+        current_package.getChildrenResources(True)
+        if resource.getClassName() == "SDSBSCompGraph"
+    ]
+
+
 def get_sd_graph_by_name(graph_name):
     """Get SD graph base on its name
 

--- a/client/ayon_substancedesigner/api/lib.py
+++ b/client/ayon_substancedesigner/api/lib.py
@@ -102,10 +102,11 @@ def get_map_identifiers_by_graph(target_graph_name):
     """
     all_map_identifiers = []
     target_graph = get_sd_graph_by_name(target_graph_name)
-    for output_node in target_graph.getOutputNodes():
-        for output in output_node.getProperties(
-            sd.api.sdproperty.SDPropertyCategory.Output):
-                all_map_identifiers.append(output.getId())
+    if target_graph:
+        for output_node in target_graph.getOutputNodes():
+            for output in output_node.getProperties(
+                sd.api.sdproperty.SDPropertyCategory.Output):
+                    all_map_identifiers.append(output.getId())
 
     return all_map_identifiers
 

--- a/client/ayon_substancedesigner/api/lib.py
+++ b/client/ayon_substancedesigner/api/lib.py
@@ -233,7 +233,7 @@ def get_output_maps_from_graphs():
 def get_colorspace_data(raw_colorspace=False):
     """Get Colorspace data of the output map
     Args:
-        raw_colorspace (bool, optional): raw colorspace data.
+        raw_colorspace (bool, optional): Use raw colorspace data.
                                          Defaults to False.
 
     Returns:

--- a/client/ayon_substancedesigner/api/lib.py
+++ b/client/ayon_substancedesigner/api/lib.py
@@ -243,10 +243,8 @@ def get_colorspace_data(raw_colorspace=False):
     app = ctx.getSDApplication()
 
     # Access the color management engine.
-    cm = app.getColorManagementEngine()
-
-    color_management_name = cm.getName()
+    color_management = app.getColorManagementEngine()
     if raw_colorspace:
-        return color_management_name.getRawColorSpaceName()
+        return color_management.getRawColorSpaceName()
     else:
-        return color_management_name.getWorkingColorSpaceName()
+        return color_management.getWorkingColorSpaceName()

--- a/client/ayon_substancedesigner/api/lib.py
+++ b/client/ayon_substancedesigner/api/lib.py
@@ -181,7 +181,7 @@ def export_outputs_by_sd_graph(instance_name, target_graph, output_dir,
     for sd_node in target_graph.getOutputNodes():
         node_definition = sd_node.getDefinition()
         for output in sd_node.getProperties(
-            sd.api.sdproperty.SDPropertyCategory.Output):
+            sdproperty.SDPropertyCategory.Output):
                 map_identifier = output.getId()
                 if map_identifier not in selected_map_identifiers:
                     continue
@@ -228,3 +228,25 @@ def get_output_maps_from_graphs():
                         all_output_maps.add(output.getId())
 
     return all_output_maps
+
+
+def get_colorspace_data(raw_colorspace=False):
+    """Get Colorspace data of the output map
+    Args:
+        raw_colorspace (bool, optional): raw colorspace data.
+                                         Defaults to False.
+
+    Returns:
+        str: colorspace name
+    """
+    ctx = sd.getContext()
+    app = ctx.getSDApplication()
+
+    # Access the color management engine.
+    cm = app.getColorManagementEngine()
+
+    color_management_name = cm.getName()
+    if raw_colorspace:
+        return color_management_name.getRawColorSpaceName()
+    else:
+        return color_management_name.getWorkingColorSpaceName()

--- a/client/ayon_substancedesigner/plugins/create/create_textures.py
+++ b/client/ayon_substancedesigner/plugins/create/create_textures.py
@@ -6,7 +6,8 @@ from ayon_core.lib import BoolDef, EnumDef
 from ayon_substancedesigner.api.pipeline import set_instance
 from ayon_substancedesigner.api.lib import (
     get_current_graph_name,
-    get_sd_graphs_by_package
+    get_sd_graphs_by_package,
+    get_output_maps_from_graphs
 )
 from ayon_substancedesigner.api.plugin import TextureCreator
 
@@ -66,7 +67,8 @@ class CreateTextures(TextureCreator):
         for key in [
             "review",
             "exportFileFormat",
-            "exportedGraphs"
+            "exportedGraphs",
+            "exportedGraphsOutputs"
         ]:
             if key in pre_create_data:
                 creator_attributes[key] = pre_create_data[key]
@@ -111,5 +113,10 @@ class CreateTextures(TextureCreator):
                     items=get_sd_graphs_by_package(),
                     multiselection=True,
                     default=None,
-                    label="Graphs To be Exported")
+                    label="Graphs To be Exported"),
+            EnumDef("exportedGraphsOutputs",
+                    items=get_output_maps_from_graphs(),
+                    multiselection=True,
+                    default=None,
+                    label="Graph Outputs To be Exported")
         ]

--- a/client/ayon_substancedesigner/plugins/create/create_textures.py
+++ b/client/ayon_substancedesigner/plugins/create/create_textures.py
@@ -85,6 +85,7 @@ class CreateTextures(TextureCreator):
                     label="File type"),
             EnumDef("exportedGraphs",
                     items=get_sd_graphs_by_package(),
+                    multiselection=True,
                     default=None,
                     label="Graphs To be Exported")
         ]

--- a/client/ayon_substancedesigner/plugins/create/create_textures.py
+++ b/client/ayon_substancedesigner/plugins/create/create_textures.py
@@ -31,6 +31,30 @@ class CreateTextures(TextureCreator):
             self.exportFileFormat = texture_settings.get(
                 "exportFileFormat", "png")
 
+    def get_dynamic_data(
+        self,
+        project_name,
+        folder_entity,
+        task_entity,
+        variant,
+        host_name,
+        instance
+    ):
+        """
+        The default product name templates for Unreal include {asset} and thus
+        we should pass that along as dynamic data.
+        """
+        dynamic_data = super(CreateTextures, self).get_dynamic_data(
+            project_name,
+            folder_entity,
+            task_entity,
+            variant,
+            host_name,
+            instance
+        )
+        dynamic_data["asset"] = folder_entity["name"]
+        return dynamic_data
+
     def create(self, product_name, instance_data, pre_create_data):
         current_graph_name = get_current_graph_name()
         if not current_graph_name:

--- a/client/ayon_substancedesigner/plugins/create/create_textures.py
+++ b/client/ayon_substancedesigner/plugins/create/create_textures.py
@@ -4,7 +4,10 @@ from ayon_core.pipeline import CreatorError
 from ayon_core.lib import BoolDef, EnumDef
 
 from ayon_substancedesigner.api.pipeline import set_instance
-from ayon_substancedesigner.api.lib import get_current_graph_name
+from ayon_substancedesigner.api.lib import (
+    get_current_graph_name,
+    get_sd_graphs_by_package
+)
 from ayon_substancedesigner.api.plugin import TextureCreator
 
 
@@ -17,6 +20,16 @@ class CreateTextures(TextureCreator):
 
     default_variant = "Main"
     settings_category = "substancedesigner"
+    review = False
+    exportFileFormat = "png"
+
+    def apply_settings(self, project_settings):
+        texture_settings = project_settings["substancedesigner"].get(
+            "create_texture", {})
+        if texture_settings:
+            self.review = texture_settings.get("review", False)
+            self.exportFileFormat = texture_settings.get(
+                "exportFileFormat", "png")
 
     def create(self, product_name, instance_data, pre_create_data):
         current_graph_name = get_current_graph_name()
@@ -28,13 +41,11 @@ class CreateTextures(TextureCreator):
             "creator_attributes", dict())
         for key in [
             "review",
-            "sbsar",
             "exportFileFormat",
+            "exportedGraphs"
         ]:
             if key in pre_create_data:
                 creator_attributes[key] = pre_create_data[key]
-
-        instance_data["graph_name"] = current_graph_name
 
         instance = self.create_instance_in_context(product_name,
                                                    instance_data)
@@ -48,7 +59,7 @@ class CreateTextures(TextureCreator):
             BoolDef("review",
                     label="Review",
                     tooltip="Mark as reviewable",
-                    default=True),
+                    default=self.review),
             EnumDef("exportFileFormat",
                     items={
                         # TODO: Get available extensions from substance API
@@ -70,6 +81,10 @@ class CreateTextures(TextureCreator):
                         #   publishing only a single file
                         # "sbsar": "sbsar",
                     },
-                    default="png",
-                    label="File type")
+                    default=self.exportFileFormat,
+                    label="File type"),
+            EnumDef("exportedGraphs",
+                    items=get_sd_graphs_by_package(),
+                    default=None,
+                    label="Graphs To be Exported")
         ]

--- a/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
@@ -26,7 +26,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             instance.data["exportedGraphs"] = creator_attrs.get(
                 "exportedGraphs", [])
         else:
-            instance.data["exportedGraph"] = get_sd_graphs_by_package()
+            instance.data["exportedGraphs"] = get_sd_graphs_by_package()
         for graph_name in instance.data["exportedGraphs"]:
             map_identifiers = get_map_identifiers_by_graph(graph_name)
             project_name = instance.context.data["projectName"]
@@ -79,16 +79,17 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             task_type,
             context.data["hostName"],
             product_type="texture",
-            variant=instance.data["variant"] + f"_{map_identifier}",
+            variant=f"{texture_set_name}",
             project_settings=context.data["project_settings"]
         )
+
         image_product_group_name = get_product_name(
             context.data["projectName"],
             task_name,
             task_type,
             context.data["hostName"],
             product_type="texture",
-            variant=instance.data["variant"],
+            variant=instance.data["variant"] + f"_{graph_name}",
             project_settings=context.data["project_settings"]
         )
         ext = instance.data["creator_attributes"].get("exportFileFormat")

--- a/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
@@ -48,12 +48,11 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
 
             for map_identifier in map_identifiers:
                 self.create_image_instance(
-                    instance, task_entity, graph_name,
+                    instance, graph_name,
                     map_identifier, staging_dir
                 )
 
-    def create_image_instance(self, instance,
-                              task_entity, graph_name,
+    def create_image_instance(self, instance, graph_name,
                               map_identifier, staging_dir):
         """Create a new instance per image.
 
@@ -65,33 +64,11 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         # Always include the map identifier
         texture_set_name = f"{graph_name}_{map_identifier}"
 
-        task_name = task_type = None
-        if task_entity:
-            task_name = task_entity["name"]
-            task_type = task_entity["taskType"]
-
         # TODO: The product type actually isn't 'texture' currently but
         #   for now this is only done so the product name starts with
         #   'texture'
-        image_product_name = get_product_name(
-            context.data["projectName"],
-            task_name,
-            task_type,
-            context.data["hostName"],
-            product_type="texture",
-            variant=f"{texture_set_name}",
-            project_settings=context.data["project_settings"]
-        )
-
-        image_product_group_name = get_product_name(
-            context.data["projectName"],
-            task_name,
-            task_type,
-            context.data["hostName"],
-            product_type="texture",
-            variant=instance.data["variant"] + f"_{graph_name}",
-            project_settings=context.data["project_settings"]
-        )
+        image_product_name = f"{instance.name}_{texture_set_name}"
+        image_product_group_name = f"{instance.name}_{texture_set_name}"
         ext = instance.data["creator_attributes"].get("exportFileFormat")
         # Prepare representation
         representation = {

--- a/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
@@ -48,11 +48,11 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
 
             for map_identifier in map_identifiers:
                 self.create_image_instance(
-                    instance, folder_entity, task_entity, graph_name,
+                    instance, task_entity, graph_name,
                     map_identifier, staging_dir
                 )
 
-    def create_image_instance(self, instance, folder_entity,
+    def create_image_instance(self, instance,
                               task_entity, graph_name,
                               map_identifier, staging_dir):
         """Create a new instance per image.
@@ -64,10 +64,6 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         context = instance.context
         # Always include the map identifier
         texture_set_name = f"{graph_name}_{map_identifier}"
-
-        folder_name = None
-        if folder_entity:
-            folder_name = folder_entity["name"]
 
         task_name = task_type = None
         if task_entity:
@@ -88,7 +84,6 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         )
         image_product_group_name = get_product_name(
             context.data["projectName"],
-            folder_name,
             task_name,
             task_type,
             context.data["hostName"],

--- a/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
@@ -29,6 +29,8 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             instance.data["exportedGraphs"] = get_sd_graphs_by_package()
         for graph_name in instance.data["exportedGraphs"]:
             map_identifiers = get_map_identifiers_by_graph(graph_name)
+            if not map_identifiers:
+                continue
             project_name = instance.context.data["projectName"]
             folder_entity = ayon_api.get_folder_by_path(
                 project_name,

--- a/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
@@ -7,7 +7,8 @@ from ayon_core.pipeline.publish import KnownPublishError
 
 from ayon_substancedesigner.api.lib import (
     get_map_identifiers_by_graph,
-    get_sd_graphs_by_package
+    get_sd_graphs_by_package,
+    get_colorspace_data
 )
 
 
@@ -105,6 +106,17 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
 
         # Store the texture set name and stack name on the instance
         image_instance.data["textureSetName"] = texture_set_name
+
+        # The current api does not support to get colorspace data
+        # from the output so the colorspace setting is hardcoded for
+        # the colorspace data accordingly to the default output setting
+        if map_identifier in ["diffuse", "basecolor"]:
+            colorspace = get_colorspace_data()
+        else:
+            colorspace = get_colorspace_data(raw_colorspace=True)
+
+        self.log.debug(f"{image_product_name} colorspace: {colorspace}")
+        image_instance.data["colorspace"] = colorspace
 
         # Store the instance in the original instance as a member
         instance.append(image_instance)

--- a/client/ayon_substancedesigner/plugins/publish/extract_textures.py
+++ b/client/ayon_substancedesigner/plugins/publish/extract_textures.py
@@ -4,7 +4,6 @@ from ayon_core.pipeline import KnownPublishError, publish
 from ayon_substancedesigner.api.lib import get_sd_graph_by_name
 
 
-
 class ExtractTextures(publish.Extractor):
     """Extract Textures as Graph Outputs
 
@@ -18,32 +17,31 @@ class ExtractTextures(publish.Extractor):
     order = publish.Extractor.order - 0.1
 
     def process(self, instance):
-        graph_name = instance.data["graph_name"]
-        target_sd_graph = get_sd_graph_by_name(graph_name)
-
         staging_dir = self.staging_dir(instance)
         extension = instance.data["creator_attributes"].get("exportFileFormat")
-
-        result = export.exportSDGraphOutputs(
-            target_sd_graph, staging_dir, extension)
-        if not result:
-            raise KnownPublishError(
-                "Failed to export texture output in graph: {}".format(
-                    graph_name)
-            )
         map_identifiers = instance.data["map_identifiers"]
-        # Rename the directories accordingly to the output maps
-        file_list_in_staging = [
-            path for path in os.listdir(staging_dir) if os.path.isfile(
-                os.path.join(staging_dir, path))
-        ]
-        for file, identifier in zip(file_list_in_staging, map_identifiers):
-            src = os.path.join(staging_dir, file)
-            dst = os.path.join(staging_dir,
-                               f"{graph_name}_{identifier}.{extension}")
-            os.rename(src, dst)
 
-        self.log.debug(f"Extracting to {staging_dir}")
+        for graph_name in instance.data["exportedGraphs"]:
+            target_sd_graph = get_sd_graph_by_name(graph_name)
+            result = export.exportSDGraphOutputs(
+                target_sd_graph, staging_dir, extension)
+            if not result:
+                raise KnownPublishError(
+                    "Failed to export texture output in graph: {}".format(
+                        graph_name)
+                )
+            # Rename the directories accordingly to the output maps
+            file_list_in_staging = [
+                path for path in os.listdir(staging_dir) if os.path.isfile(
+                    os.path.join(staging_dir, path))
+            ]
+            for file, identifier in zip(file_list_in_staging, map_identifiers):
+                src = os.path.join(staging_dir, file)
+                dst = os.path.join(staging_dir,
+                                f"{graph_name}_{identifier}.{extension}")
+                os.rename(src, dst)
+
+            self.log.debug(f"Extracting to {staging_dir}")
         # The TextureSet instance should not be integrated. It generates no
         # output data. Instead the separated texture instances are generated
         # from it which themselves integrate into the database.

--- a/client/ayon_substancedesigner/plugins/publish/extract_textures.py
+++ b/client/ayon_substancedesigner/plugins/publish/extract_textures.py
@@ -5,7 +5,8 @@ from ayon_substancedesigner.api.lib import (
 )
 
 
-class ExtractTextures(publish.Extractor):
+class ExtractTextures(publish.Extractor,
+                      publish.ColormanagedPyblishPluginMixin):
     """Extract Textures as Graph Outputs
 
     """
@@ -37,6 +38,22 @@ class ExtractTextures(publish.Extractor):
                 )
 
             self.log.debug(f"Extracting to {staging_dir}")
+        # We'll insert the color space data for each image instance that we
+        # added into this texture set. The collector couldn't do so because
+        # some anatomy and other instance data needs to be collected prior
+        context = instance.context
+        for image_instance in instance:
+            representation = next(iter(image_instance.data["representations"]))
+
+            colorspace = image_instance.data.get("colorspace")
+            if not colorspace:
+                self.log.debug("No color space data present for instance: "
+                               f"{image_instance}")
+                continue
+
+            self.set_representation_colorspace(representation,
+                                               context=context,
+                                               colorspace=colorspace)
         # The TextureSet instance should not be integrated. It generates no
         # output data. Instead the separated texture instances are generated
         # from it which themselves integrate into the database.

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -2,13 +2,45 @@ from ayon_server.settings import BaseSettingsModel, SettingsField
 from .imageio import ImageIOSettings, DEFAULT_IMAGEIO_SETTINGS
 
 
+def image_format_enum():
+    """Return enumerator for image output formats."""
+    return [
+        {"label": "bmp", "value": "bmp"},
+        {"label": "dds", "value": "dds"},
+        {"label": "jpeg", "value": "jpeg"},
+        {"label": "png", "value": "png"},
+        {"label": "tga", "value": "tga"},
+        {"label": "tif", "value": "tif"},
+        {"label": "surface", "value": "surface"},
+        {"label": "hdr", "value": "hdr"},
+        {"label": "exr", "value": "exr"},
+        {"label": "jif", "value": "jif"},
+        {"label": "jpe", "value": "jpe"},
+        {"label": "webp", "value": "webp"},
+    ]
+
+
+class CreateTextureSettings(BaseSettingsModel):
+    review : bool = SettingsField(False, title="Review")
+    exportFileFormat: str = SettingsField(
+        enum_resolver=image_format_enum,
+        title="Image Output File Type")
+
 class SubstanceDesignerSettings(BaseSettingsModel):
     imageio: ImageIOSettings = SettingsField(
         default_factory=ImageIOSettings,
         title="Color Management (ImageIO)"
     )
+    create_texture: CreateTextureSettings = SettingsField(
+        default_factory=CreateTextureSettings,
+        title="Create Textures"
+    )
 
 
 DEFAULT_SD_SETTINGS = {
     "imageio": DEFAULT_IMAGEIO_SETTINGS,
+    "create_texture": {
+        "review": False,
+        "exportFileFormat": "png"
+    }
 }


### PR DESCRIPTION
## Changelog Description
General refactoring and enhancing Textures Product Type:
- Sync the settings of image format and review with server settings.
![image](https://github.com/user-attachments/assets/d3fd3cda-9d16-4dd4-823f-409f8a071e29)

- Supports to export selected graphs and selected output nodes
![image](https://github.com/user-attachments/assets/d729b41b-050f-409a-b09a-6890b661f134)

Resolve # https://github.com/ynput/ayon-substance-designer/issues/5, https://github.com/ynput/ayon-substance-designer/issues/7,  https://github.com/ynput/ayon-substance-designer/issues/10, https://github.com/ynput/ayon-substance-designer/issues/6, https://github.com/ynput/ayon-substance-designer/issues/9,  

## Additional review information
Need to test along with core addon https://github.com/ynput/ayon-core/pull/1129
- If you want to publish the instances, you still need to load one of the graphs.
- Colorspace data is somehow hardcoded according to the default exported colorspace data 
![image](https://github.com/user-attachments/assets/d261f2cb-371f-4d55-a7ee-a80326347022)


## Testing notes:
1. Launch Substance Designer
2. Create Texture
3. Play around with the new settings.
