### PR TITLE
Project Creation with user-defined templates and template files

### DIFF
--- a/client/ayon_substancedesigner/api/pipeline.py
+++ b/client/ayon_substancedesigner/api/pipeline.py
@@ -59,7 +59,7 @@ class SubstanceDesignerHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_loader_plugin_path(LOAD_PATH)
         register_creator_plugin_path(CREATE_PATH)
 
-        log.info("Installing callbacks ... ")
+        # log.info("Installing callbacks ... ")
         # self._register_callbacks()
 
         log.info("Installing menu ... ")

--- a/client/ayon_substancedesigner/api/pipeline.py
+++ b/client/ayon_substancedesigner/api/pipeline.py
@@ -64,7 +64,9 @@ class SubstanceDesignerHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
         log.info("Installing menu ... ")
         self._install_menu()
-        create_project_with_from_template()
+
+        if os.environ["AVALON_OPEN_LAST_WORKFILE"] == 0:
+            create_project_with_from_template()
 
         self._has_been_setup = True
 

--- a/client/ayon_substancedesigner/api/pipeline.py
+++ b/client/ayon_substancedesigner/api/pipeline.py
@@ -65,7 +65,7 @@ class SubstanceDesignerHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         log.info("Installing menu ... ")
         self._install_menu()
 
-        if os.environ["AVALON_OPEN_LAST_WORKFILE"] == 0:
+        if os.environ["AVALON_OPEN_LAST_WORKFILE"] == "0":
             create_project_with_from_template()
 
         self._has_been_setup = True

--- a/client/ayon_substancedesigner/api/pipeline.py
+++ b/client/ayon_substancedesigner/api/pipeline.py
@@ -27,7 +27,7 @@ from .lib import (
     set_sd_metadata,
     parsing_sd_data
 )
-
+from .project_creation import create_project_with_from_template
 
 log = logging.getLogger("ayon_substancedesigner")
 
@@ -59,11 +59,12 @@ class SubstanceDesignerHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_loader_plugin_path(LOAD_PATH)
         register_creator_plugin_path(CREATE_PATH)
 
-        # log.info("Installing callbacks ... ")
+        log.info("Installing callbacks ... ")
         # self._register_callbacks()
 
         log.info("Installing menu ... ")
         self._install_menu()
+        create_project_with_from_template()
 
         self._has_been_setup = True
 

--- a/client/ayon_substancedesigner/api/pipeline.py
+++ b/client/ayon_substancedesigner/api/pipeline.py
@@ -67,6 +67,9 @@ class SubstanceDesignerHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
         if os.environ["AVALON_OPEN_LAST_WORKFILE"] == "0":
             create_project_with_from_template()
+        last_workfile = os.environ["AYON_LAST_WORKFILE"]
+        if not os.path.exists(last_workfile):
+            create_project_with_from_template()
 
         self._has_been_setup = True
 

--- a/client/ayon_substancedesigner/api/project_creation.py
+++ b/client/ayon_substancedesigner/api/project_creation.py
@@ -14,8 +14,7 @@ from ayon_core.settings import get_current_project_settings
 log = logging.getLogger("ayon_substancedesigner")
 
 def parse_graph_from_template(graph_name, project_template, template_filepath):
-    """Add graph by referencing the template
-
+    """Parse graph by project template name from Substance template file
     Args:
         graph_name (str): graph_name
         project_template (str): project template name

--- a/client/ayon_substancedesigner/api/project_creation.py
+++ b/client/ayon_substancedesigner/api/project_creation.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+import os
+import sd
+from sd.api.sdapplication import SDApplicationPath
+from sd.api.sbs.sdsbscompgraph import SDSBSCompGraph
+from ayon_core.pipeline import tempdir, get_current_project_name
+from ayon_core.settings import get_current_project_settings
+
+
+
+# def metallic_roughness_template(graph_name):
+#     xml_data = f"""
+# <graph><identifier v="{"{graph_name}"}"/><uid v="1530982368"/>
+# <graphtype v="material"/><graphOutputs><graphoutput><identifier v="basecolor"/>
+# <uid v="1213284336"/><attributes><label v="Base Color"/></attributes>
+# <usages><usage><components v="RGBA"/><name v="baseColor"/></usage></usages>
+# <group v="Material"/></graphoutput><graphoutput><identifier v="normal"/>
+# <uid v="1213284338"/><attributes><label v="Normal"/></attributes>
+# <usages><usage><components v="RGBA"/><name v="normal"/></usage></usages>
+# <group v="Material"/></graphoutput><graphoutput><identifier v="roughness"/>
+# <uid v="1213284340"/><attributes><label v="Roughness"/></attributes><usages>
+# <usage><components v="RGBA"/><name v="roughness"/></usage></usages>
+# <channels v="2"/><group v="Material"/></graphoutput><graphoutput>
+# <identifier v="metallic"/><uid v="1213284342"/><attributes><label v="Metallic"/>
+# </attributes><usages><usage><components v="RGBA"/><name v="metallic"/></usage>
+# </usages><channels v="2"/><group v="Material"/></graphoutput><graphoutput>
+# <identifier v="height"/><uid v="1279137031"/><attributes><label v="Height"/>
+# </attributes><usages><usage><components v="RGBA"/><name v="height"/></usage>
+# </usages><channels v="2"/><group v="Material"/></graphoutput><graphoutput>
+# <identifier v="ambientocclusion"/><uid v="1359211721"/><attributes>
+# <label v="Ambient Occlusion"/></attributes><usages><usage>
+# <components v="RGBA"/><name v="ambientOcclusion"/></usage></usages><channels v="2"/>
+# <group v="Material"/></graphoutput></graphOutputs><compNodes><compNode>
+# <uid v="1213284337"/><connections><connection><identifier v="inputNodeOutput"/>
+# <connRef v="1359211355"/><connRefOutput v="1359211356"/></connection>
+# </connections><GUILayout><gpos v="-48 -240 0"/></GUILayout><compImplementation>
+# <compOutputBridge><output v="1213284336"/></compOutputBridge></compImplementation>
+# </compNode><compNode><uid v="1213284339"/><connections><connection>
+# <identifier v="inputNodeOutput"/><connRef v="1359211383"/><connRefOutput v="1359211384"/>
+# </connection></connections><GUILayout><gpos v="-48 -80 0"/></GUILayout><compImplementation>
+# <compOutputBridge><output v="1213284338"/></compOutputBridge></compImplementation></compNode>
+# <compNode><uid v="1213284341"/><connections><connection><identifier v="inputNodeOutput"/>
+# <connRef v="1359211391"/><connRefOutput v="1359211392"/></connection></connections><GUILayout>
+# <gpos v="-48 80 0"/></GUILayout><compImplementation><compOutputBridge><output v="1213284340"/>
+# </compOutputBridge></compImplementation></compNode><compNode><uid v="1213284343"/><connections><connection>
+# <identifier v="inputNodeOutput"/><connRef v="1359211407"/><connRefOutput v="1359211408"/>
+# </connection></connections><GUILayout><gpos v="-48 240 0"/></GUILayout><compImplementation>
+# <compOutputBridge><output v="1213284342"/></compOutputBridge></compImplementation></compNode><compNode>
+# <uid v="1279137030"/><connections><connection><identifier v="inputNodeOutput"/><connRef v="1359211415"/>
+# <connRefOutput v="1359211408"/></connection></connections><GUILayout><gpos v="-48 560 0"/></GUILayout>
+# <compImplementation><compOutputBridge><output v="1279137031"/></compOutputBridge></compImplementation>
+# </compNode><compNode><uid v="1359211355"/><GUILayout><gpos v="-208 -240 0"/></GUILayout><compOutputs>
+# <compOutput><uid v="1359211356"/><comptype v="1"/></compOutput></compOutputs><compImplementation>
+# <compFilter><filter v="uniform"/><parameters><parameter><name v="outputcolor"/><relativeTo v="0"/>
+# <paramValue><constantValueFloat4 v="0.5 0.5 0.5 1"/></paramValue></parameter></parameters></compFilter>
+# </compImplementation></compNode><compNode><uid v="1359211383"/><GUILayout><gpos v="-208 -80 0"/>
+# </GUILayout><compOutputs><compOutput><uid v="1359211384"/><comptype v="1"/></compOutput>
+# </compOutputs><compImplementation><compFilter><filter v="normal"/><parameters><parameter>
+# <name v="input2alpha"/><relativeTo v="0"/><paramValue><constantValueBool v="0"/></paramValue>
+# </parameter></parameters></compFilter></compImplementation></compNode><compNode><uid v="1359211391"/>
+# <GUILayout><gpos v="-208 80 0"/></GUILayout><compOutputs><compOutput><uid v="1359211392"/><comptype v="2"/>
+# </compOutput></compOutputs><compImplementation><compFilter><filter v="uniform"/><parameters><parameter>
+# <name v="colorswitch"/><relativeTo v="0"/><paramValue><constantValueBool v="0"/></paramValue></parameter>
+# <parameter><name v="outputcolor"/><relativeTo v="0"/><paramValue><constantValueFloat4 v="0.25 0.25 0.25 1"/>
+# </paramValue></parameter></parameters></compFilter></compImplementation></compNode>
+# <compNode><uid v="1359211407"/><GUILayout><gpos v="-208 240 0"/></GUILayout><compOutputs><compOutput>
+# <uid v="1359211408"/><comptype v="2"/></compOutput></compOutputs><compImplementation><compFilter>
+# <filter v="uniform"/><parameters><parameter><name v="colorswitch"/><relativeTo v="0"/><paramValue>
+# <constantValueBool v="0"/></paramValue></parameter></parameters></compFilter></compImplementation></compNode>
+# <compNode><uid v="1359211415"/><GUILayout><gpos v="-208 560 501"/></GUILayout><compOutputs><compOutput><uid v="1359211408"/>
+# <comptype v="2"/></compOutput></compOutputs><compImplementation><compFilter><filter v="uniform"/><parameters><parameter>
+# <name v="colorswitch"/><relativeTo v="0"/><paramValue><constantValueBool v="0"/></paramValue></parameter><parameter>
+# <name v="outputcolor"/><relativeTo v="0"/><paramValue><constantValueFloat4 v="0.5 0.5 0.5 1"/></paramValue></parameter>
+# </parameters></compFilter></compImplementation></compNode><compNode><uid v="1359211719"/><GUILayout><gpos v="-208 400 0"/>
+# </GUILayout><compOutputs><compOutput><uid v="1359211408"/><comptype v="2"/></compOutput></compOutputs><compImplementation>
+# <compFilter><filter v="uniform"/><parameters><parameter><name v="colorswitch"/><relativeTo v="0"/><paramValue><constantValueBool v="0"/>
+# </paramValue></parameter><parameter><name v="outputcolor"/><relativeTo v="0"/><paramValue><constantValueFloat4 v="1 1 1 1"/></paramValue>
+# </parameter></parameters></compFilter></compImplementation></compNode><compNode><uid v="1359211720"/><connections><connection>
+# <identifier v="inputNodeOutput"/><connRef v="1359211719"/><connRefOutput v="1359211408"/></connection></connections>
+# <GUILayout><gpos v="-48 400 0"/></GUILayout><compImplementation><compOutputBridge><output v="1359211721"/></compOutputBridge>
+# </compImplementation></compNode></compNodes><baseParameters/><options><option><name v="defaultParentSize"/><value v="11x11"/>
+# </option></options><root><rootOutputs><rootOutput><output v="1213284336"/><format v="0"/><usertag v=""/>
+# </rootOutput><rootOutput><output v="1213284338"/><format v="0"/><usertag v=""/></rootOutput><rootOutput>
+# <output v="1213284340"/><format v="0"/><usertag v=""/></rootOutput><rootOutput><output v="1213284342"/><format v="0"/>
+# <usertag v=""/></rootOutput><rootOutput><output v="1279137031"/><format v="0"/><usertag v=""/></rootOutput><rootOutput>
+# <output v="1359211721"/><format v="0"/><usertag v=""/></rootOutput></rootOutputs></root></graph>
+
+# """.format(graph_name)
+
+#     return xml_data
+
+
+def create_tmp_package_for_template(sd_pkg_mgr, project_name):
+    """Create temp substance package for template graph
+
+    Args:
+        sd_pkg_mgr (sd.api.sdpackagemgr.SDPackageMgr): package manager
+        project_name (str): project_name
+
+    Returns:
+        sd.api.sdpackage.SDPackage, str: SD Package and template file path
+
+    """
+    temp_package = sd_pkg_mgr.newUserPackage()
+    staging_dir = tempdir.get_temp_dir(
+        project_name, use_local_temp=True
+    )
+    path = os.path.join(staging_dir, "temp_ayon_package.sbs")
+    sd_pkg_mgr.savePackageAs(temp_package, fileAbsPath=path)
+
+    return temp_package, path
+
+
+def add_graph_from_template(project_settings=None):
+    if project_settings is None:
+        project_settings = get_current_project_settings()
+    project_name = get_current_project_name()
+    sd_context = sd.getContext()
+    sd_app = sd_context.getSDApplication()
+    sd_pkg_mgr = sd_app.getPackageMgr()
+    package, filepath = create_tmp_package_for_template(
+        sd_pkg_mgr, project_name
+    )
+    resources_dir = sd_app.getPath(SDApplicationPath.DefaultResourcesDir)
+    project_creation_settings = project_settings["substancedesigner"].get(
+        "DesignerProjectCreation", {})
+    project_template_settings = project_creation_settings.get(
+        "project_templates", [])
+    for project_template_setting in project_template_settings:
+        graph_name = project_template_setting["name"]
+        project_template = project_template_setting["project_workflow"]
+        template_filename = get_template_filename_from_project_settings(
+            resources_dir, project_template)
+        if not template_filename:
+            new_empty_graph = SDSBSCompGraph.sNew(package)
+            new_empty_graph.setIdentifier(graph_name)
+            return
+    #TODO: template setup with xml edit
+
+    sd_pkg_mgr.loadUserPackage(
+        filepath, updatePackages=True, reloadIfModified=True
+    )
+
+
+def get_template_filename_from_project_settings(resources_dir, project_template):
+    """Get template filename from ayon project settings
+
+    Args:
+        resources_dir (sd.api.sdapplication.SDApplicationPath): resources directory
+        project_template (str): project template name
+
+    Returns:
+        str: absolute filepath of the sbs template file.
+    """
+    if project_template in [
+        "metallic_roughness",
+        "metallic_roughness_anisotropy",
+        "metallic_roughness_coated",
+        "metallic_roughness_sheen",
+        "adobe_standard_material"
+    ]:
+        return os.path.join(
+            resources_dir, "02_pbr_metallic_roughness.sbs")
+    elif project_template == "specular_glossiness":
+        return os.path.join(
+            resources_dir, "03_pbr_specular_glossiness.sbs")
+    elif project_template == "blinn":
+        return os.path.join(
+            resources_dir, "04_blinn.sbs")
+    elif project_template == "scan_metallic_roughness":
+        return os.path.join(
+            resources_dir, "05_scan_pbr_metallic_roughness.sbs")
+    elif project_template == "scan_specular_glossiness":
+        return os.path.join(
+            resources_dir, "06_scan_pbr_specular_glossiness.sbs")
+    elif project_template == "axf_to_metallic_roughness":
+        return os.path.join(
+            resources_dir, "07_axf_to_pbr_metallic_roughness.sbs")
+    elif project_template == "axf_to_specular_glossiness":
+        return os.path.join(
+            resources_dir, "08_axf_to_pbr_specular_glossiness.sbs")
+    elif project_template == "axf_to_axf":
+        return os.path.join(
+            resources_dir, "09_axf_to_axf.sbs")
+    elif project_template == "studio_panorama":
+        return os.path.join(
+            resources_dir, "10_studio_panorama.sbs")
+    elif project_template in [
+        "sp_filter_generic",
+        "sp_filter_specific",
+        "sp_filter_channel_mesh_maps",
+        "sp_generator_mesh_maps"
+    ]:
+        return os.path.join(
+            resources_dir, "11_substance_painter.sbs")
+    elif project_template == "sample_filter":
+        return os.path.join(
+            resources_dir, "12_substance_sampler.sbs")
+    elif project_template == "clo_metallic_roughness":
+        return os.path.join(
+            resources_dir, "13_clo_metallic_roughness.sbs")
+
+    return None

--- a/client/ayon_substancedesigner/api/project_creation.py
+++ b/client/ayon_substancedesigner/api/project_creation.py
@@ -117,10 +117,6 @@ def create_project_with_from_template(project_settings=None):
     sd_context = sd.getContext()
     sd_app = sd_context.getSDApplication()
     sd_pkg_mgr = sd_app.getPackageMgr()
-    for package in sd_pkg_mgr.getUserPackages():
-        for resource in package.getChildrenResources(True):
-            if resource.getClassName() == "SDSBSCompGraph":
-                return
 
     if project_settings is None:
         project_settings = get_current_project_settings()

--- a/client/ayon_substancedesigner/api/project_creation.py
+++ b/client/ayon_substancedesigner/api/project_creation.py
@@ -2,7 +2,6 @@
 import os
 import sd
 import logging
-import math
 import xml.etree.ElementTree as etree
 
 from sd.api.sdapplication import SDApplicationPath

--- a/client/ayon_substancedesigner/api/project_creation.py
+++ b/client/ayon_substancedesigner/api/project_creation.py
@@ -5,7 +5,6 @@ import logging
 import xml.etree.ElementTree as etree
 
 from sd.api.sdapplication import SDApplicationPath
-from sd.api.sbs.sdsbscompgraph import SDSBSCompGraph
 
 from ayon_core.pipeline import tempdir, get_current_project_name
 from ayon_core.settings import get_current_project_settings
@@ -34,9 +33,8 @@ def parse_graph_from_template(graph_name, project_template, template_filepath):
             break
 
     if graph_element is None:
-        print(
-            f"Graph with identifier '{project_template}' "
-            f"not found in {template_filepath}."
+        log.warning(
+            f"Graph with identifier '{project_template}' not found in {template_filepath}."
         )
         exit()
 
@@ -70,7 +68,7 @@ def add_graphs_to_package(parsed_graph_names, temp_package_filepath):
     # Save the modified content for Substance file
     unsaved_tree.write(temp_package_filepath, encoding='utf-8', xml_declaration=True)
 
-    print("All graphs are copied and pasted successfully!")
+    log.warning("All graphs are copied and pasted successfully!")
 
 
 def create_tmp_package_for_template(sd_pkg_mgr, project_name):

--- a/client/ayon_substancedesigner/api/project_creation.py
+++ b/client/ayon_substancedesigner/api/project_creation.py
@@ -1,93 +1,71 @@
 # -*- coding: utf-8 -*-
 import os
 import sd
+import logging
+import xml.etree.ElementTree as etree
+
 from sd.api.sdapplication import SDApplicationPath
 from sd.api.sbs.sdsbscompgraph import SDSBSCompGraph
+
 from ayon_core.pipeline import tempdir, get_current_project_name
 from ayon_core.settings import get_current_project_settings
 
 
+log = logging.getLogger("ayon_substancedesigner")
 
-# def metallic_roughness_template(graph_name):
-#     xml_data = f"""
-# <graph><identifier v="{"{graph_name}"}"/><uid v="1530982368"/>
-# <graphtype v="material"/><graphOutputs><graphoutput><identifier v="basecolor"/>
-# <uid v="1213284336"/><attributes><label v="Base Color"/></attributes>
-# <usages><usage><components v="RGBA"/><name v="baseColor"/></usage></usages>
-# <group v="Material"/></graphoutput><graphoutput><identifier v="normal"/>
-# <uid v="1213284338"/><attributes><label v="Normal"/></attributes>
-# <usages><usage><components v="RGBA"/><name v="normal"/></usage></usages>
-# <group v="Material"/></graphoutput><graphoutput><identifier v="roughness"/>
-# <uid v="1213284340"/><attributes><label v="Roughness"/></attributes><usages>
-# <usage><components v="RGBA"/><name v="roughness"/></usage></usages>
-# <channels v="2"/><group v="Material"/></graphoutput><graphoutput>
-# <identifier v="metallic"/><uid v="1213284342"/><attributes><label v="Metallic"/>
-# </attributes><usages><usage><components v="RGBA"/><name v="metallic"/></usage>
-# </usages><channels v="2"/><group v="Material"/></graphoutput><graphoutput>
-# <identifier v="height"/><uid v="1279137031"/><attributes><label v="Height"/>
-# </attributes><usages><usage><components v="RGBA"/><name v="height"/></usage>
-# </usages><channels v="2"/><group v="Material"/></graphoutput><graphoutput>
-# <identifier v="ambientocclusion"/><uid v="1359211721"/><attributes>
-# <label v="Ambient Occlusion"/></attributes><usages><usage>
-# <components v="RGBA"/><name v="ambientOcclusion"/></usage></usages><channels v="2"/>
-# <group v="Material"/></graphoutput></graphOutputs><compNodes><compNode>
-# <uid v="1213284337"/><connections><connection><identifier v="inputNodeOutput"/>
-# <connRef v="1359211355"/><connRefOutput v="1359211356"/></connection>
-# </connections><GUILayout><gpos v="-48 -240 0"/></GUILayout><compImplementation>
-# <compOutputBridge><output v="1213284336"/></compOutputBridge></compImplementation>
-# </compNode><compNode><uid v="1213284339"/><connections><connection>
-# <identifier v="inputNodeOutput"/><connRef v="1359211383"/><connRefOutput v="1359211384"/>
-# </connection></connections><GUILayout><gpos v="-48 -80 0"/></GUILayout><compImplementation>
-# <compOutputBridge><output v="1213284338"/></compOutputBridge></compImplementation></compNode>
-# <compNode><uid v="1213284341"/><connections><connection><identifier v="inputNodeOutput"/>
-# <connRef v="1359211391"/><connRefOutput v="1359211392"/></connection></connections><GUILayout>
-# <gpos v="-48 80 0"/></GUILayout><compImplementation><compOutputBridge><output v="1213284340"/>
-# </compOutputBridge></compImplementation></compNode><compNode><uid v="1213284343"/><connections><connection>
-# <identifier v="inputNodeOutput"/><connRef v="1359211407"/><connRefOutput v="1359211408"/>
-# </connection></connections><GUILayout><gpos v="-48 240 0"/></GUILayout><compImplementation>
-# <compOutputBridge><output v="1213284342"/></compOutputBridge></compImplementation></compNode><compNode>
-# <uid v="1279137030"/><connections><connection><identifier v="inputNodeOutput"/><connRef v="1359211415"/>
-# <connRefOutput v="1359211408"/></connection></connections><GUILayout><gpos v="-48 560 0"/></GUILayout>
-# <compImplementation><compOutputBridge><output v="1279137031"/></compOutputBridge></compImplementation>
-# </compNode><compNode><uid v="1359211355"/><GUILayout><gpos v="-208 -240 0"/></GUILayout><compOutputs>
-# <compOutput><uid v="1359211356"/><comptype v="1"/></compOutput></compOutputs><compImplementation>
-# <compFilter><filter v="uniform"/><parameters><parameter><name v="outputcolor"/><relativeTo v="0"/>
-# <paramValue><constantValueFloat4 v="0.5 0.5 0.5 1"/></paramValue></parameter></parameters></compFilter>
-# </compImplementation></compNode><compNode><uid v="1359211383"/><GUILayout><gpos v="-208 -80 0"/>
-# </GUILayout><compOutputs><compOutput><uid v="1359211384"/><comptype v="1"/></compOutput>
-# </compOutputs><compImplementation><compFilter><filter v="normal"/><parameters><parameter>
-# <name v="input2alpha"/><relativeTo v="0"/><paramValue><constantValueBool v="0"/></paramValue>
-# </parameter></parameters></compFilter></compImplementation></compNode><compNode><uid v="1359211391"/>
-# <GUILayout><gpos v="-208 80 0"/></GUILayout><compOutputs><compOutput><uid v="1359211392"/><comptype v="2"/>
-# </compOutput></compOutputs><compImplementation><compFilter><filter v="uniform"/><parameters><parameter>
-# <name v="colorswitch"/><relativeTo v="0"/><paramValue><constantValueBool v="0"/></paramValue></parameter>
-# <parameter><name v="outputcolor"/><relativeTo v="0"/><paramValue><constantValueFloat4 v="0.25 0.25 0.25 1"/>
-# </paramValue></parameter></parameters></compFilter></compImplementation></compNode>
-# <compNode><uid v="1359211407"/><GUILayout><gpos v="-208 240 0"/></GUILayout><compOutputs><compOutput>
-# <uid v="1359211408"/><comptype v="2"/></compOutput></compOutputs><compImplementation><compFilter>
-# <filter v="uniform"/><parameters><parameter><name v="colorswitch"/><relativeTo v="0"/><paramValue>
-# <constantValueBool v="0"/></paramValue></parameter></parameters></compFilter></compImplementation></compNode>
-# <compNode><uid v="1359211415"/><GUILayout><gpos v="-208 560 501"/></GUILayout><compOutputs><compOutput><uid v="1359211408"/>
-# <comptype v="2"/></compOutput></compOutputs><compImplementation><compFilter><filter v="uniform"/><parameters><parameter>
-# <name v="colorswitch"/><relativeTo v="0"/><paramValue><constantValueBool v="0"/></paramValue></parameter><parameter>
-# <name v="outputcolor"/><relativeTo v="0"/><paramValue><constantValueFloat4 v="0.5 0.5 0.5 1"/></paramValue></parameter>
-# </parameters></compFilter></compImplementation></compNode><compNode><uid v="1359211719"/><GUILayout><gpos v="-208 400 0"/>
-# </GUILayout><compOutputs><compOutput><uid v="1359211408"/><comptype v="2"/></compOutput></compOutputs><compImplementation>
-# <compFilter><filter v="uniform"/><parameters><parameter><name v="colorswitch"/><relativeTo v="0"/><paramValue><constantValueBool v="0"/>
-# </paramValue></parameter><parameter><name v="outputcolor"/><relativeTo v="0"/><paramValue><constantValueFloat4 v="1 1 1 1"/></paramValue>
-# </parameter></parameters></compFilter></compImplementation></compNode><compNode><uid v="1359211720"/><connections><connection>
-# <identifier v="inputNodeOutput"/><connRef v="1359211719"/><connRefOutput v="1359211408"/></connection></connections>
-# <GUILayout><gpos v="-48 400 0"/></GUILayout><compImplementation><compOutputBridge><output v="1359211721"/></compOutputBridge>
-# </compImplementation></compNode></compNodes><baseParameters/><options><option><name v="defaultParentSize"/><value v="11x11"/>
-# </option></options><root><rootOutputs><rootOutput><output v="1213284336"/><format v="0"/><usertag v=""/>
-# </rootOutput><rootOutput><output v="1213284338"/><format v="0"/><usertag v=""/></rootOutput><rootOutput>
-# <output v="1213284340"/><format v="0"/><usertag v=""/></rootOutput><rootOutput><output v="1213284342"/><format v="0"/>
-# <usertag v=""/></rootOutput><rootOutput><output v="1279137031"/><format v="0"/><usertag v=""/></rootOutput><rootOutput>
-# <output v="1359211721"/><format v="0"/><usertag v=""/></rootOutput></rootOutputs></root></graph>
 
-# """.format(graph_name)
+def create_project_with_template(project_template, template_filepath,
+                                 temp_package_filepath, log=None):
+    """Create project with template
 
-#     return xml_data
+    Args:
+        project_template (str): project template name
+        template_filepath (str): Substance template filepath
+        temp_package_filepath (str): temp package filepath
+        log(log.logger): log message
+
+    """
+    # Parse the template substance file
+    substance_tree = etree.parse(template_filepath)
+    substance_root = substance_tree.getroot()
+
+    # Find the <graph> element with the specified identifier
+    graph_element = None
+    for graph in substance_root.findall('.//graph'):
+        identifier = graph.find('identifier')
+        if identifier is not None and identifier.attrib.get('v') == project_template:
+            graph_element = graph
+            break
+
+    if graph_element is None:
+        log.warning(
+            f"Graph with identifier '{project_template}' "
+            f"not found in {template_filepath}."
+        )
+        exit()
+
+    # Parse the temp package file
+    unsaved_tree = etree.parse(temp_package_filepath)
+    unsaved_root = unsaved_tree.getroot()
+
+    # Find the <content> element in Unsaved_Package.xml
+    content_element = unsaved_root.find('content')
+
+    # Remove the existing <content/> element if it exists
+    if content_element is not None:
+        unsaved_root.remove(content_element)
+
+    # Create a new <content> element and append the copied <graph> element
+    new_content = etree.Element('content')
+    new_content.append(graph_element)  # Append the copied <graph> element
+    unsaved_root.append(new_content)   # Add the new <content> to the root
+
+    # Save the modified content for Substance file
+    unsaved_tree.write(temp_package_filepath, encoding='utf-8', xml_declaration=True)
+
+    log.warning(
+        f"Graph with identifier '{project_template}' copied and pasted successfully!"
+    )
 
 
 def create_tmp_package_for_template(sd_pkg_mgr, project_name):
@@ -106,6 +84,7 @@ def create_tmp_package_for_template(sd_pkg_mgr, project_name):
         project_name, use_local_temp=True
     )
     path = os.path.join(staging_dir, "temp_ayon_package.sbs")
+    path = os.path.normpath(path)
     sd_pkg_mgr.savePackageAs(temp_package, fileAbsPath=path)
 
     return temp_package, path
@@ -118,7 +97,7 @@ def add_graph_from_template(project_settings=None):
     sd_context = sd.getContext()
     sd_app = sd_context.getSDApplication()
     sd_pkg_mgr = sd_app.getPackageMgr()
-    package, filepath = create_tmp_package_for_template(
+    package, package_filepath = create_tmp_package_for_template(
         sd_pkg_mgr, project_name
     )
     resources_dir = sd_app.getPath(SDApplicationPath.DefaultResourcesDir)
@@ -129,16 +108,22 @@ def add_graph_from_template(project_settings=None):
     for project_template_setting in project_template_settings:
         graph_name = project_template_setting["name"]
         project_template = project_template_setting["project_workflow"]
-        template_filename = get_template_filename_from_project_settings(
-            resources_dir, project_template)
-        if not template_filename:
+        template_filepath = get_template_filename_from_project_settings(
+            resources_dir, project_template
+        )
+        template_filepath = os.path.normpath(template_filepath)
+        if not template_filepath:
             new_empty_graph = SDSBSCompGraph.sNew(package)
             new_empty_graph.setIdentifier(graph_name)
             return
-    #TODO: template setup with xml edit
+
+        # create project_with_template
+        create_project_with_template(
+            project_template, template_filepath, package_filepath, log=log
+        )
 
     sd_pkg_mgr.loadUserPackage(
-        filepath, updatePackages=True, reloadIfModified=True
+        package_filepath, updatePackages=True, reloadIfModified=True
     )
 
 

--- a/client/ayon_substancedesigner/api/project_creation.py
+++ b/client/ayon_substancedesigner/api/project_creation.py
@@ -20,6 +20,7 @@ from ayon_substancedesigner.api.lib import get_sd_graph_by_name
 
 log = logging.getLogger("ayon_substancedesigner")
 
+
 def parse_graph_from_template(graph_name, project_template, template_filepath):
     """Parse graph by project template name from Substance template file
     Args:
@@ -135,10 +136,26 @@ def create_project_with_from_template(project_settings=None):
     output_res_by_graphs = {}
     for project_template_setting in project_template_settings:
         graph_name = project_template_setting["name"]
-        project_template = project_template_setting["project_workflow"]
-        template_filepath = get_template_filename_from_project_settings(
-            resources_dir, project_template
-        )
+        if project_template_setting["template_type"] == "default_substance_template":
+            project_template = project_template_setting["default_substance_template"]
+            template_filepath = get_template_filename_from_project_settings(
+                resources_dir, project_template
+            )
+        else:
+            custom_template = project_template_setting["custom_template"]
+            project_template = custom_template["custom_template_graph"]
+            if not project_template:
+                log.warning("Project template not filled. Skipping project creation.")
+                continue
+
+            template_filepath = custom_template["custom_template_path"]
+            if not template_filepath:
+                log.warning("Template path not filled. Skipping project creation.")
+                continue
+            if not os.path.exists(template_filepath):
+                log.warning("Template path does not exist yet. Skipping project creation.")
+                continue
+
         template_filepath = os.path.normpath(template_filepath)
         parsed_graph = parse_graph_from_template(
             graph_name, project_template, template_filepath)

--- a/client/ayon_substancedesigner/api/project_creation.py
+++ b/client/ayon_substancedesigner/api/project_creation.py
@@ -148,7 +148,7 @@ def create_project_with_from_template(project_settings=None):
             ):
                 project_template = project_template_setting.get(
                     "default_substance_template")
-                template_filepath = get_template_filename_from_project_settings(
+                template_filepath = get_template_filename_from_project(
                     resources_dir, project_template
                 )
         else:
@@ -190,8 +190,8 @@ def create_project_with_from_template(project_settings=None):
     set_output_resolution_by_graphs(output_res_by_graphs)
 
 
-def get_template_filename_from_project_settings(resources_dir,
-                                                project_template):
+def get_template_filename_from_project(resources_dir,
+                                       project_template):
     """Get template filename from ayon project settings
 
     Args:

--- a/client/ayon_substancedesigner/api/project_creation.py
+++ b/client/ayon_substancedesigner/api/project_creation.py
@@ -14,9 +14,9 @@ from ayon_core.settings import get_current_project_settings
 log = logging.getLogger("ayon_substancedesigner")
 
 
-def create_project_with_template(project_template, template_filepath,
-                                 temp_package_filepath, log=None):
-    """Create project with template
+def add_graph_with_template(project_template, template_filepath,
+                            temp_package_filepath):
+    """Add graph by referencing the template
 
     Args:
         project_template (str): project template name
@@ -38,7 +38,7 @@ def create_project_with_template(project_template, template_filepath,
             break
 
     if graph_element is None:
-        log.warning(
+        print(
             f"Graph with identifier '{project_template}' "
             f"not found in {template_filepath}."
         )
@@ -63,7 +63,7 @@ def create_project_with_template(project_template, template_filepath,
     # Save the modified content for Substance file
     unsaved_tree.write(temp_package_filepath, encoding='utf-8', xml_declaration=True)
 
-    log.warning(
+    print(
         f"Graph with identifier '{project_template}' copied and pasted successfully!"
     )
 
@@ -90,21 +90,36 @@ def create_tmp_package_for_template(sd_pkg_mgr, project_name):
     return temp_package, path
 
 
-def add_graph_from_template(project_settings=None):
-    if project_settings is None:
-        project_settings = get_current_project_settings()
-    project_name = get_current_project_name()
+def create_project_with_from_template(project_settings=None):
+    """Create Project from template setting
+
+    Args:
+        project_settings (str, optional): project settings. Defaults to None.
+    """
     sd_context = sd.getContext()
     sd_app = sd_context.getSDApplication()
     sd_pkg_mgr = sd_app.getPackageMgr()
+    for package in sd_pkg_mgr.getUserPackages():
+        for resource in package.getChildrenResources(True):
+            if resource.getClassName() == "SDSBSCompGraph":
+                return
+
+    if project_settings is None:
+        project_settings = get_current_project_settings()
+
+    project_name = get_current_project_name()
     package, package_filepath = create_tmp_package_for_template(
         sd_pkg_mgr, project_name
     )
+
     resources_dir = sd_app.getPath(SDApplicationPath.DefaultResourcesDir)
     project_creation_settings = project_settings["substancedesigner"].get(
         "DesignerProjectCreation", {})
     project_template_settings = project_creation_settings.get(
         "project_templates", [])
+    if not project_creation_settings:
+        return
+
     for project_template_setting in project_template_settings:
         graph_name = project_template_setting["name"]
         project_template = project_template_setting["project_workflow"]
@@ -112,14 +127,15 @@ def add_graph_from_template(project_settings=None):
             resources_dir, project_template
         )
         template_filepath = os.path.normpath(template_filepath)
+        print(template_filepath)
         if not template_filepath:
             new_empty_graph = SDSBSCompGraph.sNew(package)
             new_empty_graph.setIdentifier(graph_name)
             return
 
-        # create project_with_template
-        create_project_with_template(
-            project_template, template_filepath, package_filepath, log=log
+        # add graph with template
+        add_graph_with_template(
+            project_template, template_filepath, package_filepath
         )
 
     sd_pkg_mgr.loadUserPackage(
@@ -137,6 +153,7 @@ def get_template_filename_from_project_settings(resources_dir, project_template)
     Returns:
         str: absolute filepath of the sbs template file.
     """
+    templates_dir = os.path.join(resources_dir, "templates")
     if project_template in [
         "metallic_roughness",
         "metallic_roughness_anisotropy",
@@ -145,31 +162,31 @@ def get_template_filename_from_project_settings(resources_dir, project_template)
         "adobe_standard_material"
     ]:
         return os.path.join(
-            resources_dir, "02_pbr_metallic_roughness.sbs")
+            templates_dir, "02_pbr_metallic_roughness.sbs")
     elif project_template == "specular_glossiness":
         return os.path.join(
-            resources_dir, "03_pbr_specular_glossiness.sbs")
+            templates_dir, "03_pbr_specular_glossiness.sbs")
     elif project_template == "blinn":
         return os.path.join(
-            resources_dir, "04_blinn.sbs")
+            templates_dir, "04_blinn.sbs")
     elif project_template == "scan_metallic_roughness":
         return os.path.join(
-            resources_dir, "05_scan_pbr_metallic_roughness.sbs")
+            templates_dir, "05_scan_pbr_metallic_roughness.sbs")
     elif project_template == "scan_specular_glossiness":
         return os.path.join(
-            resources_dir, "06_scan_pbr_specular_glossiness.sbs")
+            templates_dir, "06_scan_pbr_specular_glossiness.sbs")
     elif project_template == "axf_to_metallic_roughness":
         return os.path.join(
-            resources_dir, "07_axf_to_pbr_metallic_roughness.sbs")
+            templates_dir, "07_axf_to_pbr_metallic_roughness.sbs")
     elif project_template == "axf_to_specular_glossiness":
         return os.path.join(
-            resources_dir, "08_axf_to_pbr_specular_glossiness.sbs")
+            templates_dir, "08_axf_to_pbr_specular_glossiness.sbs")
     elif project_template == "axf_to_axf":
         return os.path.join(
-            resources_dir, "09_axf_to_axf.sbs")
+            templates_dir, "09_axf_to_axf.sbs")
     elif project_template == "studio_panorama":
         return os.path.join(
-            resources_dir, "10_studio_panorama.sbs")
+            templates_dir, "10_studio_panorama.sbs")
     elif project_template in [
         "sp_filter_generic",
         "sp_filter_specific",
@@ -177,12 +194,12 @@ def get_template_filename_from_project_settings(resources_dir, project_template)
         "sp_generator_mesh_maps"
     ]:
         return os.path.join(
-            resources_dir, "11_substance_painter.sbs")
+            templates_dir, "11_substance_painter.sbs")
     elif project_template == "sample_filter":
         return os.path.join(
-            resources_dir, "12_substance_sampler.sbs")
+            templates_dir, "12_substance_sampler.sbs")
     elif project_template == "clo_metallic_roughness":
         return os.path.join(
-            resources_dir, "13_clo_metallic_roughness.sbs")
+            templates_dir, "13_clo_metallic_roughness.sbs")
 
     return None

--- a/client/ayon_substancedesigner/api/project_creation.py
+++ b/client/ayon_substancedesigner/api/project_creation.py
@@ -127,7 +127,6 @@ def create_project_with_from_template(project_settings=None):
             resources_dir, project_template
         )
         template_filepath = os.path.normpath(template_filepath)
-        print(template_filepath)
         if not template_filepath:
             new_empty_graph = SDSBSCompGraph.sNew(package)
             new_empty_graph.setIdentifier(graph_name)

--- a/client/ayon_substancedesigner/api/project_creation.py
+++ b/client/ayon_substancedesigner/api/project_creation.py
@@ -133,8 +133,7 @@ def create_project_with_from_template(project_settings=None):
     resources_dir = sd_app.getPath(SDApplicationPath.DefaultResourcesDir)
     project_creation_settings = project_settings["substancedesigner"].get(
         "project_creation", {})
-    if project_creation_settings.get("enabled", False):
-        return
+
     project_template_settings = project_creation_settings.get(
         "project_templates", [])
     if not project_creation_settings:

--- a/client/ayon_substancedesigner/api/project_creation.py
+++ b/client/ayon_substancedesigner/api/project_creation.py
@@ -37,13 +37,16 @@ def parse_graph_from_template(graph_name, project_template, template_filepath):
     graph_element = None
     for graph in substance_root.findall('.//graph'):
         identifier = graph.find('identifier')
-        if identifier is not None and identifier.attrib.get('v') == project_template:
-            graph_element = graph
-            break
+        if identifier is not None and (
+            identifier.attrib.get('v') == project_template
+            ):
+                graph_element = graph
+                break
 
     if graph_element is None:
         log.warning(
-            f"Graph with identifier '{project_template}' not found in {template_filepath}."
+            f"Graph with identifier '{project_template}' "
+            f"not found in {template_filepath}."
         )
         exit()
 
@@ -75,7 +78,11 @@ def add_graphs_to_package(parsed_graph_names, temp_package_filepath):
     new_content.extend(parsed_graph_names)  # Append the copied <graph> element
     unsaved_root.append(new_content)   # Add the new <content> to the root
     # Save the modified content for Substance file
-    unsaved_tree.write(temp_package_filepath, encoding='utf-8', xml_declaration=True)
+    unsaved_tree.write(
+        temp_package_filepath,
+        encoding='utf-8',
+        xml_declaration=True
+    )
 
     log.warning("All graphs are copied and pasted successfully!")
 
@@ -136,24 +143,30 @@ def create_project_with_from_template(project_settings=None):
     output_res_by_graphs = {}
     for project_template_setting in project_template_settings:
         graph_name = project_template_setting["name"]
-        if project_template_setting["template_type"] == "default_substance_template":
-            project_template = project_template_setting["default_substance_template"]
-            template_filepath = get_template_filename_from_project_settings(
-                resources_dir, project_template
-            )
+        if project_template_setting["template_type"] == (
+            "default_substance_template"
+            ):
+                project_template = project_template_setting.get(
+                    "default_substance_template")
+                template_filepath = get_template_filename_from_project_settings(
+                    resources_dir, project_template
+                )
         else:
             custom_template = project_template_setting["custom_template"]
             project_template = custom_template["custom_template_graph"]
             if not project_template:
-                log.warning("Project template not filled. Skipping project creation.")
+                log.warning("Project template not filled. "
+                            "Skipping project creation.")
                 continue
 
             template_filepath = custom_template["custom_template_path"]
             if not template_filepath:
-                log.warning("Template path not filled. Skipping project creation.")
+                log.warning("Template path not filled. "
+                            "Skipping project creation.")
                 continue
             if not os.path.exists(template_filepath):
-                log.warning("Template path does not exist yet. Skipping project creation.")
+                log.warning("Template path does not exist yet. "
+                            "Skipping project creation.")
                 continue
 
         template_filepath = os.path.normpath(template_filepath)
@@ -177,11 +190,12 @@ def create_project_with_from_template(project_settings=None):
     set_output_resolution_by_graphs(output_res_by_graphs)
 
 
-def get_template_filename_from_project_settings(resources_dir, project_template):
+def get_template_filename_from_project_settings(resources_dir,
+                                                project_template):
     """Get template filename from ayon project settings
 
     Args:
-        resources_dir (sd.api.sdapplication.SDApplicationPath): resources directory
+        resources_dir (sd.api.sdapplication.SDApplicationPath): resources dir
         project_template (str): project template name
 
     Returns:

--- a/client/ayon_substancedesigner/api/project_creation.py
+++ b/client/ayon_substancedesigner/api/project_creation.py
@@ -132,7 +132,9 @@ def create_project_with_from_template(project_settings=None):
 
     resources_dir = sd_app.getPath(SDApplicationPath.DefaultResourcesDir)
     project_creation_settings = project_settings["substancedesigner"].get(
-        "DesignerProjectCreation", {})
+        "project_creation", {})
+    if project_creation_settings.get("enabled", False):
+        return
     project_template_settings = project_creation_settings.get(
         "project_templates", [])
     if not project_creation_settings:

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -46,15 +46,19 @@ def template_workflow_enum():
 
 def document_resolution_enum():
     return [
-        {"label": "16", "value": 16},
-        {"label": "32", "value": 32},
-        {"label": "64", "value": 32},
-        {"label": "128", "value": 128},
-        {"label": "256", "value": 256},
-        {"label": "512", "value": 512},
-        {"label": "1024", "value": 1024},
-        {"label": "2048", "value": 2048},
-        {"label": "4096", "value": 4096}
+        {"label": "2", "value": 1},
+        {"label": "4", "value": 2},
+        {"label": "8", "value": 3},
+        {"label": "16", "value": 4},
+        {"label": "32", "value": 5},
+        {"label": "64", "value": 6},
+        {"label": "128", "value": 7},
+        {"label": "256", "value": 8},
+        {"label": "512", "value": 9},
+        {"label": "1024", "value": 10},
+        {"label": "2048", "value": 11},
+        {"label": "4096", "value": 12},
+        {"label": "8192", "value": 13}
     ]
 
 

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -2,13 +2,100 @@ from ayon_server.settings import BaseSettingsModel, SettingsField
 from .imageio import ImageIOSettings, DEFAULT_IMAGEIO_SETTINGS
 
 
+def template_workflow_enum():
+    return [
+        {"label": "Empty", "value": "empty"},
+        {"label": "Metallic Roughness", "value": "metallic_roughness"},
+        {"label": "Metallic Roughness - Anisotropy",
+         "value": "metallic_roughness_anisotropy"},
+        {"label": "Metallic Roughness - Coated",
+         "value": "metallic_roughness_coated"},
+        {"label": "Metallic Roughness - SSS",
+         "value": "metallic_roughness_sss"},
+        {"label": "Metallic Roughness - Sheen",
+         "value": "metallic_roughness_sheen"},
+        {"label": "Adobe Standard Material",
+         "value": "adobe_standard_material"},
+        {"label": "Specular Glossiness", "value": "specular_glossiness"},
+        {"label": "Blinn", "value": "blinn"},
+        {"label": "Scan Processing - Metallic Roughness",
+         "value": "scan_metallic_roughness"},
+        {"label": "Scan Processing - Specular Glossiness",
+         "value": "scan_specular_glossiness"},
+        {"label": "Scan Processing - Specular Glossiness",
+         "value": "scan_specular_glossiness"},
+        {"label": "AxF to Metallic Roughness",
+         "value": "axf_to_metallic_roughness"},
+        {"label": "AxF to Specular Glossiness",
+         "value": "axf_to_specular_glossiness"},
+        {"label": "AxF to AxF", "value": "axf_to_axf"},
+        {"label": "Studio Panorama", "value": "studio_panorama"},
+        {"label": "Painter Filter (generic)",
+         "value": "sp_filter_generic"},
+        {"label": "Painter Filter (specific)",
+         "value": "sp_filter_specific"},
+        {"label": "Painter Filter (specific w/ mesh maps)",
+         "value": "sp_filter_channel_mesh_maps"},
+        {"label": "Painter Generator (w/ mesh maps)",
+         "value": "sp_generator_mesh_maps"},
+        {"label": "Sample Filter", "value": "sample_filter"},
+        {"label": "CLO Metallic Roughness",
+         "value": "clo_metallic_roughness"},
+    ]
+
+
+def document_resolution_enum():
+    return [
+        {"label": "16", "value": 16},
+        {"label": "32", "value": 32},
+        {"label": "64", "value": 32},
+        {"label": "128", "value": 128},
+        {"label": "256", "value": 256},
+        {"label": "512", "value": 512},
+        {"label": "1024", "value": 1024},
+        {"label": "2048", "value": 2048},
+        {"label": "4096", "value": 4096}
+    ]
+
+
+class ProjectTemplatesModel(BaseSettingsModel):
+    _layout = "expanded"
+    name: str = SettingsField("default", title="Template Name")
+    default_texture_resolution: int = SettingsField(
+        1024, enum_resolver=document_resolution_enum,
+        title="Document Resolution",
+        description=("Set texture resolution when "
+                     "creating new project.")
+    )
+    project_workflow: str = SettingsField(
+        "empty", enum_resolver=template_workflow_enum,
+        title="Template",
+        description=("Choose template to create your "
+                     "Substance Graph.")
+    )
+
+
+class ProjectTemplateSettingModel(BaseSettingsModel):
+    project_templates: list[ProjectTemplatesModel] = SettingsField(
+        default_factory=ProjectTemplatesModel,
+        title="Project Templates"
+    )
+
+
 class SubstanceDesignerSettings(BaseSettingsModel):
     imageio: ImageIOSettings = SettingsField(
         default_factory=ImageIOSettings,
         title="Color Management (ImageIO)"
     )
+    DesignerProjectCreation: ProjectTemplateSettingModel = SettingsField(
+        default_factory=ProjectTemplateSettingModel,
+        title="Designer Project Creation"
+    )
 
 
 DEFAULT_SD_SETTINGS = {
     "imageio": DEFAULT_IMAGEIO_SETTINGS,
+    "DesignerProjectCreation": {
+        "project_templates": []
+    }
 }

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -44,6 +44,14 @@ def template_workflow_enum():
     ]
 
 
+def template_type_enum():
+    return [
+        {"label": "Default Substance Template",
+         "value": "default_substance_template"},
+        {"label": "Custom Template", "value": "custom_template"},
+    ]
+
+
 def document_resolution_enum():
     return [
         {"label": "2", "value": 1},
@@ -80,22 +88,48 @@ def image_format_enum():
     ]
 
 
+class CustomTemplateModel(BaseSettingsModel):
+    _layout = "expanded"
+    custom_template_graph: str = SettingsField(
+        "",
+        title="Custom Template Graph"
+    )
+    custom_template_path: str = SettingsField(
+        "",
+        title="Custom Template Filepath",
+
+    )
+
+
 class ProjectTemplatesModel(BaseSettingsModel):
     _layout = "expanded"
     name: str = SettingsField("default", title="Template Name")
     default_texture_resolution: int = SettingsField(
-        1024, enum_resolver=document_resolution_enum,
+        10, enum_resolver=document_resolution_enum,
         title="Document Resolution",
         description=("Set texture resolution when "
                      "creating new project.")
     )
-    project_workflow: str = SettingsField(
+    template_type: str = SettingsField(
+        "default_substance_template",
+        title="Template Type",
+        description=("Choose either default substance templates "
+                     "or custom template for project creation"),
+        enum_resolver=template_type_enum,
+        conditionalEnum=True,
+    )
+
+    default_substance_template: str = SettingsField(
         "empty", enum_resolver=template_workflow_enum,
         title="Template",
         description=("Choose template to create your "
                      "Substance Graph.")
     )
-
+    custom_template: CustomTemplateModel = SettingsField(
+        title="Custom Template",
+        description="What custom template to use for project creation",
+        default_factory=CustomTemplateModel,
+    )
 
 class ProjectTemplateSettingModel(BaseSettingsModel):
     project_templates: list[ProjectTemplatesModel] = SettingsField(

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -132,6 +132,7 @@ class ProjectTemplatesModel(BaseSettingsModel):
     )
 
 class ProjectTemplateSettingModel(BaseSettingsModel):
+    enabled: bool = SettingsField(False, title="Enabled")
     project_templates: list[ProjectTemplatesModel] = SettingsField(
         default_factory=ProjectTemplatesModel,
         title="Project Templates"
@@ -163,6 +164,7 @@ class SubstanceDesignerSettings(BaseSettingsModel):
 DEFAULT_SD_SETTINGS = {
     "imageio": DEFAULT_IMAGEIO_SETTINGS,
     "project_creation": {
+        "enabled": False,
         "project_templates": []
     },
     "create_texture": {

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -92,11 +92,16 @@ class CustomTemplateModel(BaseSettingsModel):
     _layout = "expanded"
     custom_template_graph: str = SettingsField(
         "",
-        title="Custom Template Graph"
+        title="Custom Template Graph Name",
+        description=(
+            "Name of the graph from the custom template"
+            "you want to create your project from"
+        )
     )
     custom_template_path: str = SettingsField(
         "",
-        title="Custom Template Filepath",
+        title="Path to Custom Template",
+        description="Absolute path of which custom template located."
 
     )
 

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -132,7 +132,6 @@ class ProjectTemplatesModel(BaseSettingsModel):
     )
 
 class ProjectTemplateSettingModel(BaseSettingsModel):
-    enabled: bool = SettingsField(False, title="Enabled")
     project_templates: list[ProjectTemplatesModel] = SettingsField(
         default_factory=ProjectTemplatesModel,
         title="Project Templates"
@@ -164,7 +163,6 @@ class SubstanceDesignerSettings(BaseSettingsModel):
 DEFAULT_SD_SETTINGS = {
     "imageio": DEFAULT_IMAGEIO_SETTINGS,
     "project_creation": {
-        "enabled": False,
         "project_templates": []
     },
     "create_texture": {


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-substance-designer/issues/4
Ability to set project creation with user-defined templates and template files
User can also choose to set the graph name and the resolution settings for the output sizes

## Additional review information
Temporary Substance files would be saved for storing the template.
For custom template, you can use `C:\Program Files\Adobe\Adobe Substance 3D Designer\resources\templates\02_pbr_metallic_roughness.sbs` for custom path, and use `metallic_roughness` as custom graph name.

## Testing notes:
1. Set your name of your graph with template
![image](https://github.com/user-attachments/assets/b39b695c-32d6-495b-9f25-ca92e4c94afd)

2. If you use the custom template, please put your filepath and the graph you want to use for your project
![image](https://github.com/user-attachments/assets/d498593d-c915-4f69-b592-429ae5b92b5e)
3. Launch Designer
4. There should be `tmp_ayon_package.sbs` created with your choice of templates.