### PR TITLE
UnloadUserPackage when loading new workfile

### DIFF
--- a/client/ayon_substancedesigner/api/pipeline.py
+++ b/client/ayon_substancedesigner/api/pipeline.py
@@ -96,6 +96,9 @@ class SubstanceDesignerHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
 
     def open_workfile(self, filepath):
         pkg_mgr = package_manager()
+        for user_pkg in pkg_mgr.getUserPackages():
+            log.warning("Unloading existing workfile...")
+            pkg_mgr.unloadUserPackage(user_pkg)
         pkg_mgr.loadUserPackage(
             filepath, updatePackages=False, reloadIfModified=False
         )


### PR DESCRIPTION
## Changelog Description
This PR is to make sure the existing workfile has been unloaded after loading new workfile

## Additional review information
n/a

## Testing notes:
1. Launch SD
2. Load workfile
