### PR TITLE
Add dependencies during project creation

### DIFF
--- a/client/ayon_substancedesigner/api/project_creation.py
+++ b/client/ayon_substancedesigner/api/project_creation.py
@@ -269,7 +269,9 @@ def create_project_with_from_template(project_settings=None):
         sd_pkg_mgr, project_name
     )
 
-    add_graphs_to_package(parsed_graph_names, parsed_dependencies, package_filepath)
+    add_graphs_to_package(
+        parsed_graph_names, parsed_dependencies, package_filepath
+    )
 
     sd_pkg_mgr.unloadUserPackage(package)
     sd_pkg_mgr.loadUserPackage(

--- a/client/ayon_substancedesigner/api/project_creation.py
+++ b/client/ayon_substancedesigner/api/project_creation.py
@@ -130,7 +130,7 @@ def add_graphs_to_package(
         xml_declaration=True
     )
 
-    log.warning("All graphs are copied and pasted successfully!")
+    log.info("All graphs are copied and pasted successfully!")
 
 
 def create_tmp_package_for_template(sd_pkg_mgr, project_name):

--- a/client/ayon_substancedesigner/api/project_creation.py
+++ b/client/ayon_substancedesigner/api/project_creation.py
@@ -97,8 +97,10 @@ def add_dependencies_from_template(dependencies, temp_package_filepath):
             unsaved_root.remove(dependencies_element)
 
         new_dependencies_content = etree.Element('dependencies')
-        new_dependencies_content.extend(dependencies)  # Append the copied <graph> element
-        unsaved_root.append(new_dependencies_content)   # Add the new <content> to the root
+        # Append the copied <dependency> element
+        new_dependencies_content.extend(dependencies)
+        # Add the new <dependencies> to the root
+        unsaved_root.append(new_dependencies_content)
     # Save the modified content for Substance file
     unsaved_tree.write(
         temp_package_filepath,


### PR DESCRIPTION
## Changelog Description
Resolve https://github.com/ynput/ayon-substance-designer/issues/19
This PR is to add dependencies which needs for loading custom generator during project creation


## Additional review information
n/a

## Testing notes:
1. Use project creation in `ayon+settings://substancedesigner/project_creation/` for different template types
![image](https://github.com/user-attachments/assets/5bf68674-8a36-433e-b4bf-7f460143db29)

2. Launch Substance
3. All the custom generators inside the graph loaded from the template should be linked nicely as expected.
