### PR TITLE
fix typo in the texture loader

### DIFF
--- a/client/ayon_substancedesigner/plugins/load/load_texture.py
+++ b/client/ayon_substancedesigner/plugins/load/load_texture.py
@@ -108,7 +108,7 @@ class SubstanceLoadProjectImage(load.LoaderPlugin):
         if not has_resource_file(current_package):
             resource_folder = sd.api.sdresourcefolder.SDResourceFolder.sNew(
                 current_package)
-            resource_folder.setIdentifier(f"{project_name}_rosources")
+            resource_folder.setIdentifier(f"{project_name}_resources")
         else:
             resource_folder = get_resource_folder(current_package)
         bitmap_resource = sd.api.sdresourcebitmap.SDResourceBitmap.sNewFromFile(                # noqa


### PR DESCRIPTION
## Changelog Description
Fix the typo found in the resource folder when loading texture

## Additional review information
n/a

## Testing notes:
1. Load texture
2. The typo should be fixed for the folder name
