### PR TITLE
CI: Fix Mkdocs Automation

### DIFF
--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -1,0 +1,20 @@
+name: Deploy MkDocs
+
+on:
+  push:
+    tags:
+      - "*"
+    branches:
+      - "bugfix/30-fix-mkdocs-ci"
+  workflow_dispatch:
+
+jobs:
+  build-mk-docs:
+    # FIXME: Update @develop to @main after `ops-repo-automation` release.
+    uses: ynput/ops-repo-automation/.github/workflows/deploy_mkdocs.yml@develop
+    with:
+      repo: ${{ github.repository }}
+    secrets:
+      YNPUT_BOT_TOKEN: ${{ secrets.YNPUT_BOT_TOKEN }}
+      CI_USER: ${{ secrets.CI_USER }}
+      CI_EMAIL: ${{ secrets.CI_EMAIL }}

--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "*"
-    branches:
-      - "bugfix/30-fix-mkdocs-ci"
   workflow_dispatch:
 
 jobs:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,12 +11,12 @@ theme:
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
       toggle:
-        icon: material/toggle-switch-off-outline
+        icon: material/weather-sunny
         name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
       toggle:
-        icon: material/toggle-switch
+        icon: material/weather-night
         name: Switch to dark mode
   logo: img/ay-symbol-blackw-full.png
   favicon: img/favicon.ico

--- a/mkdocs_requirements.txt
+++ b/mkdocs_requirements.txt
@@ -1,0 +1,9 @@
+mkdocs-material >= 9.6.7
+mkdocs-autoapi >= 0.4.0
+mkdocstrings-python >= 1.16.2
+mkdocs-minify-plugin >= 0.8.0
+markdown-checklist >= 0.4.4
+mdx-gh-links >= 0.4
+pymdown-extensions >= 10.14.3
+mike >= 2.1.3
+mkdocstrings-shell >= 1.0.2


### PR DESCRIPTION
## Changelog Description
Add a CI action to trigger MK Docs deployment on creating new tags.
when testing the CI action manually (trigger from Action tab manually on GH), it will generate a `dummy-build` version that will be deleted as soon as a tag is created.

resolve #30

## Additional Notes
This PR ports https://github.com/ynput/ayon-core/pull/1441 fixes for applications addon.

This PR add some cosmetics: 
1. update light and dark mode icons. 
2. move requirements file to root location of the repo to avoid moving it along with the docs build.

## Testing notes:
1. go to https://docs.ayon.dev/ayon-substance-designer/latest/ you should find light/dark icons are updated and the latest is pointing to `test-build`.
since the workflow doesn't exist in main branch yet, I had to add on push temporarily in 5c55bddcc6be560aa8a84d80f6732f3a09ef85ea to run the action and revert it in a later commit.