### PR TITLE
Product base types: add support to creators

### DIFF
--- a/client/ayon_substancedesigner/api/pipeline.py
+++ b/client/ayon_substancedesigner/api/pipeline.py
@@ -90,9 +90,13 @@ class SubstanceDesignerHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     def save_workfile(self, dst_path=None):
         pkg_mgr = package_manager()
         package = get_package_from_current_graph()
-        if package:
-            pkg_mgr.savePackageAs(package, fileAbsPath=dst_path)
-            return dst_path
+        if not package:
+            raise RuntimeError(
+                "No current graph found in the package."
+            )
+
+        pkg_mgr.savePackageAs(package, fileAbsPath=dst_path)
+        return dst_path
 
     def open_workfile(self, filepath):
         pkg_mgr = package_manager()

--- a/client/ayon_substancedesigner/api/plugin.py
+++ b/client/ayon_substancedesigner/api/plugin.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Creator plugin for creating textures."""
-import inspect
 from ayon_core.pipeline import CreatedInstance, Creator, CreatorError
 
 from ayon_substancedesigner.api.pipeline import (

--- a/client/ayon_substancedesigner/api/plugin.py
+++ b/client/ayon_substancedesigner/api/plugin.py
@@ -53,23 +53,12 @@ class TextureCreator(Creator):
 
     # Helper methods (this might get moved into Creator class)
     def create_instance_in_context(self, product_name, data):
-        instance_kwargs = {
-            "product_type": self.product_type,
-            "product_name": product_name,
-            "data": data,
-            "creator": self,
-        }
-
-        # this is here to retain compatibility with older ayon-core
-        # but should be removed in future
-        if hasattr(self, "product_base_type"):
-            signature = inspect.signature(CreatedInstance)
-            if "product_base_type" in signature.parameters:
-                instance_kwargs["product_base_type"] = (
-                    self.product_base_type
-                )
-
-        instance = CreatedInstance(**instance_kwargs)
+        instance = CreatedInstance(
+            product_type=self.product_type,
+            product_name=product_name,
+            data=data,
+            creator=self
+        )
         self.create_context.creator_adds_instance(instance)
         return instance
 

--- a/client/ayon_substancedesigner/api/plugin.py
+++ b/client/ayon_substancedesigner/api/plugin.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Creator plugin for creating textures."""
+import inspect
 from ayon_core.pipeline import CreatedInstance, Creator, CreatorError
 
 from ayon_substancedesigner.api.pipeline import (
@@ -52,9 +53,23 @@ class TextureCreator(Creator):
 
     # Helper methods (this might get moved into Creator class)
     def create_instance_in_context(self, product_name, data):
-        instance = CreatedInstance(
-            self.product_type, product_name, data, self
-        )
+        instance_kwargs = {
+            "product_type": self.product_type,
+            "product_name": product_name,
+            "data": data,
+            "creator": self,
+        }
+
+        # this is here to retain compatibility with older ayon-core
+        # but should be removed in future
+        if hasattr(self, "product_base_type"):
+            signature = inspect.signature(CreatedInstance)
+            if "product_base_type" in signature.parameters:
+                instance_kwargs["product_base_type"] = (
+                    self.product_base_type
+                )
+
+        instance = CreatedInstance(**instance_kwargs)
         self.create_context.creator_adds_instance(instance)
         return instance
 

--- a/client/ayon_substancedesigner/plugins/create/create_sbsar.py
+++ b/client/ayon_substancedesigner/plugins/create/create_sbsar.py
@@ -6,6 +6,7 @@ class CreateSbsar(TextureCreator):
     identifier = "io.ayon.creators.substancedesigner.sbsar"
     label = "Sbsar"
     product_type = "sbsar"
+    product_base_type = "sbsar"
     icon = "picture-o"
 
     default_variant = "Main"

--- a/client/ayon_substancedesigner/plugins/create/create_textures.py
+++ b/client/ayon_substancedesigner/plugins/create/create_textures.py
@@ -17,6 +17,7 @@ class CreateTextures(TextureCreator):
     identifier = "io.ayon.creators.substancedesigner.textureset"
     label = "Textures"
     product_type = "textureSet"
+    product_base_type = "textureSet"
     icon = "picture-o"
 
     default_variant = "Main"

--- a/client/ayon_substancedesigner/plugins/create/create_workfile.py
+++ b/client/ayon_substancedesigner/plugins/create/create_workfile.py
@@ -108,23 +108,12 @@ class CreateWorkfile(AutoCreator):
         set_instances(instance_data_by_id, update=True)
 
     def create_instance_in_context(self, product_name, data):
-        instance_kwargs = {
-            "product_type": self.product_type,
-            "product_name": product_name,
-            "data": data,
-            "creator": self,
-        }
-
-        # this is here to retain compatibility with older ayon-core
-        # but should be removed in future
-        if hasattr(self, "product_base_type"):
-            signature = inspect.signature(CreatedInstance)
-            if "product_base_type" in signature.parameters:
-                instance_kwargs["product_base_type"] = (
-                    self.product_base_type
-                )
-
-        instance = CreatedInstance(**instance_kwargs)
+        instance = CreatedInstance(
+            product_type=self.product_type,
+            product_name=product_name,
+            data=data,
+            creator=self
+        )
         self.create_context.creator_adds_instance(instance)
         return instance
 

--- a/client/ayon_substancedesigner/plugins/create/create_workfile.py
+++ b/client/ayon_substancedesigner/plugins/create/create_workfile.py
@@ -15,6 +15,7 @@ class CreateWorkfile(AutoCreator):
     identifier = "io.ayon.creators.substancedesigner.workfile"
     label = "Workfile"
     product_type = "workfile"
+    product_base_type = "workfile"
     icon = "document"
 
     default_variant = "Main"

--- a/client/ayon_substancedesigner/plugins/create/create_workfile.py
+++ b/client/ayon_substancedesigner/plugins/create/create_workfile.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Creator plugin for creating workfiles."""
+import inspect
 from ayon_core.pipeline import CreatedInstance, AutoCreator
 
 from ayon_substancedesigner.api.pipeline import (
@@ -107,9 +108,23 @@ class CreateWorkfile(AutoCreator):
         set_instances(instance_data_by_id, update=True)
 
     def create_instance_in_context(self, product_name, data):
-        instance = CreatedInstance(
-            self.product_type, product_name, data, self
-        )
+        instance_kwargs = {
+            "product_type": self.product_type,
+            "product_name": product_name,
+            "data": data,
+            "creator": self,
+        }
+
+        # this is here to retain compatibility with older ayon-core
+        # but should be removed in future
+        if hasattr(self, "product_base_type"):
+            signature = inspect.signature(CreatedInstance)
+            if "product_base_type" in signature.parameters:
+                instance_kwargs["product_base_type"] = (
+                    self.product_base_type
+                )
+
+        instance = CreatedInstance(**instance_kwargs)
         self.create_context.creator_adds_instance(instance)
         return instance
 

--- a/client/ayon_substancedesigner/plugins/create/create_workfile.py
+++ b/client/ayon_substancedesigner/plugins/create/create_workfile.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Creator plugin for creating workfiles."""
-import inspect
 from ayon_core.pipeline import CreatedInstance, AutoCreator
 
 from ayon_substancedesigner.api.pipeline import (

--- a/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
@@ -94,6 +94,7 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         image_instance.data["label"] = image_product_name
         image_instance.data["productName"] = image_product_name
         image_instance.data["productType"] = product_type
+        image_instance.data["productBaseType"] = product_type
         image_instance.data["family"] = product_type
         image_instance.data["families"] = [product_type, "textures"]
         if instance.data["creator_attributes"].get("review"):


### PR DESCRIPTION
## Changelog Description
This PR is to implement product alias in Substance Designer
Resolve https://github.com/ynput/ayon-substance-designer/issues/33

## Additional review information
Offtrack to this PR
In regard to the update of the core addon, `ayon+settings://core/tools/creator/product_name_profiles/9/template` needs to changed to `T_{Task[name]}{variant}`
<img width="1038" height="345" alt="image" src="https://github.com/user-attachments/assets/6f4cbff6-6940-467c-b5de-c7a56baf0132" />


## Testing notes:
1. Launch Substance Designer
2. Create Instance along with the existing instance
3. Publish
