### PR TITLE
Create: Remove 'get_dynamic_data'

### DIFF
--- a/client/ayon_substancedesigner/plugins/create/create_textures.py
+++ b/client/ayon_substancedesigner/plugins/create/create_textures.py
@@ -25,30 +25,6 @@ class CreateTextures(TextureCreator):
     review = False
     exportFileFormat = "png"
 
-    def get_dynamic_data(
-        self,
-        project_name,
-        folder_entity,
-        task_entity,
-        variant,
-        host_name,
-        instance
-    ):
-        """
-        The default product name templates for Unreal include {asset} and thus
-        we should pass that along as dynamic data.
-        """
-        dynamic_data = super(CreateTextures, self).get_dynamic_data(
-            project_name,
-            folder_entity,
-            task_entity,
-            variant,
-            host_name,
-            instance
-        )
-        dynamic_data["asset"] = folder_entity["name"]
-        return dynamic_data
-
     def create(self, product_name, instance_data, pre_create_data):
         current_graph_name = get_current_graph_name()
         if not current_graph_name:


### PR DESCRIPTION
## Changelog Description
Remove `get_dynamic_data` from create plugin.

## Additional review information
The logic added `"asset"` which should not be available for a very long time, so the question is if we can safely merge this without core requirement bump.

## Testing notes:
1. It is possible to use `{folder[name]}` in product name now.
