### PR TITLE
🏛️Product base types: Product types and base types

### DIFF
--- a/client/ayon_substancedesigner/api/plugin.py
+++ b/client/ayon_substancedesigner/api/plugin.py
@@ -32,8 +32,13 @@ class TextureCreator(Creator):
 
     def collect_instances(self):
         for instance in get_instances():
-            if (instance.get("creator_identifier") == self.identifier or
-                    instance.get("productType") == self.product_type):
+            product_base_type = instance.get("productBaseType")
+            if not product_base_type:
+                product_base_type = instance.get("productType")
+            if (
+                instance.get("creator_identifier") == self.identifier
+                or product_base_type == self.product_base_type
+            ):
                 self.create_instance_in_context_from_existing(instance)
 
     def update_instances(self, update_list):

--- a/client/ayon_substancedesigner/api/plugin.py
+++ b/client/ayon_substancedesigner/api/plugin.py
@@ -57,8 +57,12 @@ class TextureCreator(Creator):
 
     # Helper methods (this might get moved into Creator class)
     def create_instance_in_context(self, product_name, data):
+        product_type = data.get("productType")
+        if not product_type:
+            product_type = self.product_base_type
         instance = CreatedInstance(
-            product_type=self.product_type,
+            product_base_type=self.product_base_type,
+            product_type=product_type,
             product_name=product_name,
             data=data,
             creator=self

--- a/client/ayon_substancedesigner/api/plugin.py
+++ b/client/ayon_substancedesigner/api/plugin.py
@@ -14,6 +14,7 @@ from .lib import get_current_graph_name
 class TextureCreator(Creator):
     """Create a texture set."""
     settings_category = "substancedesigner"
+    skip_discovery = True
 
     def create(self, product_name, instance_data, pre_create_data):
         current_graph_name = get_current_graph_name()

--- a/client/ayon_substancedesigner/plugins/create/create_sbsar.py
+++ b/client/ayon_substancedesigner/plugins/create/create_sbsar.py
@@ -10,4 +10,3 @@ class CreateSbsar(TextureCreator):
     icon = "picture-o"
 
     default_variant = "Main"
-    settings_category = "substancedesigner"

--- a/client/ayon_substancedesigner/plugins/create/create_sbsar.py
+++ b/client/ayon_substancedesigner/plugins/create/create_sbsar.py
@@ -5,8 +5,8 @@ class CreateSbsar(TextureCreator):
     """Create a texture set."""
     identifier = "io.ayon.creators.substancedesigner.sbsar"
     label = "Sbsar"
-    product_type = "sbsar"
     product_base_type = "sbsar"
+    product_type = product_base_type
     icon = "picture-o"
 
     default_variant = "Main"

--- a/client/ayon_substancedesigner/plugins/create/create_textures.py
+++ b/client/ayon_substancedesigner/plugins/create/create_textures.py
@@ -21,7 +21,6 @@ class CreateTextures(TextureCreator):
     icon = "picture-o"
 
     default_variant = "Main"
-    settings_category = "substancedesigner"
     review = False
     exportFileFormat = "png"
 

--- a/client/ayon_substancedesigner/plugins/create/create_textures.py
+++ b/client/ayon_substancedesigner/plugins/create/create_textures.py
@@ -16,8 +16,8 @@ class CreateTextures(TextureCreator):
     """Create a texture set."""
     identifier = "io.ayon.creators.substancedesigner.textureset"
     label = "Textures"
-    product_type = "textureSet"
     product_base_type = "textureSet"
+    product_type = product_base_type
     icon = "picture-o"
 
     default_variant = "Main"

--- a/client/ayon_substancedesigner/plugins/create/create_workfile.py
+++ b/client/ayon_substancedesigner/plugins/create/create_workfile.py
@@ -61,6 +61,7 @@ class CreateWorkfile(AutoCreator):
                 task_entity=task_entity,
                 variant=variant,
                 host_name=host_name,
+                product_type=self.product_type,
             )
             data = {
                 "folderPath": folder_path,
@@ -81,6 +82,7 @@ class CreateWorkfile(AutoCreator):
                 task_entity=task_entity,
                 variant=variant,
                 host_name=host_name,
+                product_type=self.product_type,
             )
             current_instance["folderPath"] = folder_path
             current_instance["task"] = task_name
@@ -113,6 +115,7 @@ class CreateWorkfile(AutoCreator):
 
     def create_instance_in_context(self, product_name, data):
         instance = CreatedInstance(
+            product_base_type=self.product_base_type,
             product_type=self.product_type,
             product_name=product_name,
             data=data,

--- a/client/ayon_substancedesigner/plugins/create/create_workfile.py
+++ b/client/ayon_substancedesigner/plugins/create/create_workfile.py
@@ -14,8 +14,8 @@ class CreateWorkfile(AutoCreator):
     """Workfile auto-creator."""
     identifier = "io.ayon.creators.substancedesigner.workfile"
     label = "Workfile"
-    product_type = "workfile"
     product_base_type = "workfile"
+    product_type = product_base_type
     icon = "document"
 
     default_variant = "Main"
@@ -93,8 +93,13 @@ class CreateWorkfile(AutoCreator):
 
     def collect_instances(self):
         for instance in get_instances():
-            if (instance.get("creator_identifier") == self.identifier or
-                    instance.get("productType") == self.product_type):
+            product_base_type = instance.get("productBaseType")
+            if not product_base_type:
+                product_base_type = instance.get("productType")
+            if (
+                instance.get("creator_identifier") == self.identifier
+                or product_base_type == self.product_base_type
+            ):
                 self.create_instance_in_context_from_existing(instance)
 
     def update_instances(self, update_list):

--- a/client/ayon_substancedesigner/plugins/create/create_workfile.py
+++ b/client/ayon_substancedesigner/plugins/create/create_workfile.py
@@ -26,10 +26,6 @@ class CreateWorkfile(AutoCreator):
         if not current_package:
             return
         variant = self.default_variant
-        project_name = self.project_name
-        folder_path = self.create_context.get_current_folder_path()
-        task_name = self.create_context.get_current_task_name()
-        host_name = self.create_context.host_name
 
         # Workfile instance should always exist and must only exist once.
         # As such we'll first check if it already exists and is collected.

--- a/client/ayon_substancedesigner/plugins/load/load_texture.py
+++ b/client/ayon_substancedesigner/plugins/load/load_texture.py
@@ -26,7 +26,8 @@ def get_resource_folder(current_package):
 class SubstanceLoadProjectImage(load.LoaderPlugin):
     """Load Texture for project"""
 
-    product_types = {"image", "textures"}
+    product_base_types = {"image", "textures"}
+    product_types = product_base_types
     representations = {"*"}
 
     label = "Load Texture"

--- a/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
+++ b/client/ayon_substancedesigner/plugins/publish/collect_textureset_images.py
@@ -82,11 +82,17 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
             "ext": ext.lstrip("."),
             "files": f"{image_product_name}.{ext}",
         }
+
         # Set up the representation for thumbnail generation
         representation["tags"] = ["review"]
         representation["stagingDir"] = staging_dir
         # Clone the instance
-        product_type = "image"
+        product_base_type = "image"
+
+        product_type = instance.data["productType"]
+        if product_type == instance.data["productBaseType"]:
+            product_type = product_base_type
+
         image_instance = context.create_instance(image_product_name)
         image_instance[:] = instance[:]
         image_instance.data.update(copy.deepcopy(dict(instance.data)))
@@ -94,9 +100,9 @@ class CollectTextureSet(pyblish.api.InstancePlugin):
         image_instance.data["label"] = image_product_name
         image_instance.data["productName"] = image_product_name
         image_instance.data["productType"] = product_type
-        image_instance.data["productBaseType"] = product_type
-        image_instance.data["family"] = product_type
-        image_instance.data["families"] = [product_type, "textures"]
+        image_instance.data["productBaseType"] = product_base_type
+        image_instance.data["family"] = product_base_type
+        image_instance.data["families"] = [product_base_type, "textures"]
         if instance.data["creator_attributes"].get("review"):
             image_instance.data["families"].append("review")
 

--- a/package.py
+++ b/package.py
@@ -22,7 +22,7 @@ ayon_server_version = ">=1.1.2"
 # Mapping of addon name to version requirements
 # - addon with specified version range must exist to be able to use this addon
 ayon_required_addons = {
-    "core": ">=1.0.12",
+    "core": ">=1.8.0",
 }
 # Mapping of addon name to version requirements
 # - if addon is used in same bundle the version range must be valid

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -163,17 +163,51 @@ class ProjectTemplateSettingModel(BaseSettingsModel):
     )
 
 
+class ProductTypeItemModel(BaseSettingsModel):
+    _layout = "compact"
+    product_type: str = SettingsField(
+        title="Product type",
+        description="Product type name",
+    )
+    label: str = SettingsField(
+        "",
+        title="Label",
+        description="Label to display in UI for the product type",
+    )
+
+
 class CreateTextureSettings(BaseSettingsModel):
     review : bool = SettingsField(False, title="Review")
     exportFileFormat: str = SettingsField(
         enum_resolver=image_format_enum,
         title="Image Output File Type")
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product type items",
+        description=(
+            "Optional list of product types that this plugin can create."
+        )
+    )
+
+
+class CreateSBSARModel(BaseSettingsModel):
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product type items",
+        description=(
+            "Optional list of product types that this plugin can create."
+        )
+    )
 
 
 class CreatePluginsModel(BaseSettingsModel):
     CreateTextures: CreateTextureSettings = SettingsField(
         default_factory=CreateTextureSettings,
         title="Create Textures"
+    )
+    CreateSbsar: CreateSBSARModel = SettingsField(
+        default_factory=CreateSBSARModel,
+        title="Create SBSAR",
     )
 
 
@@ -190,6 +224,7 @@ class SubstanceDesignerSettings(BaseSettingsModel):
         default_factory=CreatePluginsModel,
         title="Creator Plugins"
     )
+
 
 DEFAULT_SD_SETTINGS = {
     "imageio": DEFAULT_IMAGEIO_SETTINGS,


### PR DESCRIPTION
## Changelog Description
Use product base types and add support for product types used as aliases.

## Additional review information
Codebase of SubstanceDesigner addon is fully using product base type as "pipeline" type and product type as an alias. Load plugins define `product_base_types` for filtering, create plugins do define `product_base_type` and the whole logic is expecting that product base type is being used in the system.

Create plugins texture and SBSAR have option to define custom product types for plate instances.

## Testing notes:
This is untested PR from my side, please make sure it is fully reviewed.
### Basics
1. Use ayon-core >= 1.8.0 or current develop if is not released yet.
2. Upload the addon to server to use new settings model.
3. Existing workfiles should load up and should be possible to publish.
4. Creating new instances should work as expected.

### Product types
1. Define product types for texture and sbsar in settings.
2. Publisher should show selection of them in pre-create attributes.
3. Create them.
5. Product name should use the product type in name (if template defines that).
6. Publish the instances.
7. Loader tool should show the product type and product base type in UI.