### PR TITLE
MK Docs: Refactor the title

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,3 @@
---8<-- "README.md"
+# AYON Substance Designer Addon API Reference
+
+--8<-- "README.md:3"


### PR DESCRIPTION
## Changelog Description
- Change the title of MK Doc to `# AYON Substance Designer Addon API Reference`

## Testing notes:
I triggered the action from cli via `gh workflow run deploy_mkdocs.yml --ref chore/38-change-title-of-mk-docs`
you can check the result here https://docs.ayon.dev/ayon-substance-designer/test-build/

Resolve #38